### PR TITLE
fix(monad logs ocsf): updates time stamp parsing

### DIFF
--- a/ocsf/v1.1.0/monad/monad-logs.yaml
+++ b/ocsf/v1.1.0/monad/monad-logs.yaml
@@ -27,7 +27,12 @@ config:
               else 99                         # Other
               end
             ),
-            "time": (.timestamp | fromdate * 1000),
+            "time": (
+              .timestamp 
+              | sub("\\.[0-9]+Z$"; "Z")  # Remove fractional seconds
+              | sub("Z$"; "+00:00")       # Replace Z with +00:00
+              | fromdate * 1000
+            ),
             "actor": {
               "user": {
                 "email": .user_email


### PR DESCRIPTION
updates the way timestamps are parsed to fix error in parsing timestamp with "z"

testing using a new pipeline with monad logs piping to /dev/null