### PR TITLE
feat: add transform to promote Avro formatted JSON to top level keys

### DIFF
--- a/ocsf/v1.1.0/avro/avro-flatten.yaml
+++ b/ocsf/v1.1.0/avro/avro-flatten.yaml
@@ -1,0 +1,31 @@
+name: "Promote Avro Nested Values"
+description: "Promote nested Avro values to the top level"
+author: "Monad"
+contributors:
+  - "https://github.com/alexs-monad"
+inputs:
+  - "salesforce-pubsub"
+tags:
+  - "v1.1.0"
+  - "avro"
+  - "salesforce"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          def flatten_avro:
+            if type == "object" then
+              if length == 1 then
+                to_entries[0].value | flatten_avro
+              else
+                with_entries(.value |= flatten_avro)
+              end
+            elif type == "array" then
+              map(flatten_avro)
+            else
+              .
+            end;
+
+          flatten_avro


### PR DESCRIPTION
In Avro JSON schema, all values are vested into an object in style {"type":"value"}.  This transform removes the object and puts "value" directly onto the top level key.