### PR TITLE
feat: Add Monad Organization Logs ECS transformation

### DIFF
--- a/ecs/v8.11.0/monad/monad-api-activity.yaml
+++ b/ecs/v8.11.0/monad/monad-api-activity.yaml
@@ -1,0 +1,108 @@
+name: "Monad Organization Logs to ECS"
+description: "Collects internal logs from Monad organizations for debugging and pipeline visibility. - Transforms to ECS Schema"
+author: "Monad"
+contributors:
+  - "https://github.com/monad-inc"
+inputs:
+  - "monad-logs"
+tags:
+  - "v8.11.0"
+  - "ecs"
+  - "monad"
+  - "api-activity"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ECS Transformation for Monad API Activity
+          #
+          # Field Mappings:
+          #   .timestamp      -> @timestamp
+          #   .id             -> event.id
+          #   .user_email     -> user.email
+          #   .resource       -> url.path
+          #   .method         -> http.request.method
+          #   .status         -> http.response.status_code
+          #   .client_info    -> user_agent.original
+          #   .client_ip      -> client.ip
+          #   .additional_info -> labels.additional_info (if not null)
+          #   .log_version    -> labels.log_version
+
+          # Helper function to determine event outcome based on HTTP status code
+          def determine_outcome:
+            if . >= 200 and . < 400 then "success"
+            elif . >= 400 and . < 500 then "failure"
+            else "failure"
+            end;
+
+          # Helper function to build labels for unmapped fields
+          def build_labels:
+            {log_version: .log_version} +
+            (if .additional_info != null then {additional_info: (.additional_info | tostring)} else {} end);
+
+          # Helper function to determine event action from HTTP method
+          def method_to_action:
+            if . == "GET" then "access"
+            elif . == "POST" then "creation"
+            elif . == "PUT" then "change"
+            elif . == "PATCH" then "change"
+            elif . == "DELETE" then "deletion"
+            else "access"
+            end;
+
+          {
+            # ECS Version
+            ecs: {
+              version: "8.11.0"
+            },
+
+            # Base fields - Primary timestamp
+            "@timestamp": .timestamp,
+
+            # Event fields
+            event: {
+              kind: "event",
+              category: ["web"],
+              type: [(.method | method_to_action)],
+              action: "\(.method) \(.resource)",
+              id: .id,
+              outcome: (.status | determine_outcome),
+              provider: "monad",
+              dataset: "monad.api_activity"
+            },
+
+            # HTTP fields
+            http: {
+              request: {
+                method: .method
+              },
+              response: {
+                status_code: (.status | floor)
+              }
+            },
+
+            # URL fields
+            url: {
+              path: .resource
+            },
+
+            # User fields
+            user: {
+              email: .user_email
+            },
+
+            # Client fields
+            client: {
+              ip: .client_ip
+            },
+
+            # User agent fields
+            user_agent: {
+              original: .client_info
+            },
+
+            # Preserve unmapped fields in labels
+            labels: build_labels
+          }


### PR DESCRIPTION
## Summary

- Adds new ECS transformation for Monad Organization Logs (API Activity)
- Transforms source data to ECS v8.11.0 schema
- Input Type ID: `monad-logs`

## Description

Collects internal logs from Monad organizations for debugging and pipeline visibility.

## Transformation Details

| Property | Value |
|----------|-------|
| **Input Type ID** | `monad-logs` |
| **Source Vendor** | Monad |
| **Input Name** | Organization Logs |
| **Target Schema** | ECS v8.11.0 |
| **File** | `ecs/v8.11.0/monad/monad-api-activity.yaml` |

## Field Mappings

| Source Field | ECS Field | Notes |
|-------------|-----------|-------|
| .timestamp | @timestamp | Primary timestamp |
| .id | event.id | Event unique identifier |
| .user_email | user.email | User performing the action |
| .resource | url.path | API resource path |
| .method | http.request.method | HTTP method (GET, POST, PUT, DELETE) |
| .status | http.response.status_code | HTTP response status code |
| .client_info | user_agent.original | Client user agent string |
| .client_ip | client.ip | Client IP address |
| .additional_info | labels.additional_info | Only if not null |
| .log_version | labels.log_version | Log schema version |

## ECS Fields Added

- `ecs.version`: "8.11.0"
- `event.kind`: "event"
- `event.category`: ["web"]
- `event.type`: Dynamic based on HTTP method (access, creation, change, deletion)
- `event.action`: Combined method and resource (e.g., "GET /api/v1/...")
- `event.outcome`: Derived from HTTP status code (success for 2xx-3xx, failure for 4xx-5xx)
- `event.provider`: "monad"
- `event.dataset`: "monad.api_activity"

## Unmapped Fields

Fields preserved in `labels`:
- `.log_version` - Schema version tracking, no direct ECS equivalent
- `.additional_info` - Only included if not null

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)