### PR TITLE
feat(microsoft): add azure sentinel schema transformation

### DIFF
--- a/ocsf/v1.1.0/microsoft/microsoft-azure-sentinel.yaml
+++ b/ocsf/v1.1.0/microsoft/microsoft-azure-sentinel.yaml
@@ -14,48 +14,26 @@ config:
     arguments:
       key: ""
       query: |
-        walk(
-          if type == "object" and has("kind") then
-              .source_kind = .kind | del(.kind)
-          else
-              .
-          end
-        ) | 
-        walk(
-          if type == "object" and has("uuid") then
-              .source_uuid = .uuid | del(.uuid)
-          else
-              .
-          end
-        ) |
-        walk(
-            if type == "object" and has("output") then
-                .source_output = .output | del(.output)
-            else
-                .
-            end
-        ) 
+        if .kind then
+            .source_kind = .kind | del(.kind)
+        end
         | 
-        walk(
-            if type == "object" and has("scan") then
-                .source_scan = .scan | del(.scan)
-            else
-                .
-            end
-        ) 
+        if .type then
+            .source_type = .type | del(.type)
+        end
+        | 
+        if .uuid then
+            .source_uuid = .uuid | del(.uuid)
+        end
+        | 
+        if .output then
+            .source_output = .output | del(.output)
+        end
         |
-        walk(
-            if type == "object" and has("id") then
-                .source_id = .id | del(.id)
-            else
-                .
-            end
-        ) 
+        if .scan then
+            .source_scan = .scan | del(.scan)
+        end
         |
-        walk(
-            if type == "object" and has("type") then
-                .source_type = .type | del(.type)
-            else
-                .
-            end
-        ) 
+        if .id then
+            .source_id = .id | del(.id)
+        end

--- a/ocsf/v1.1.0/microsoft/microsoft-azure-sentinel.yaml
+++ b/ocsf/v1.1.0/microsoft/microsoft-azure-sentinel.yaml
@@ -1,0 +1,61 @@
+name: "Microsoft Sentinel compliant schema"
+description: "Transforms incoming data's schema to rename Azure Sentinel reserved keywords. This transform is not guaranteed to contain all possible keywords preserved by Azure Sentinel."
+author: "Monad"
+contributors:
+- "https://github.com/mon-aneesh"
+tags:
+- "v1.1.0"
+- "microsoft"
+- "azure"
+- "sentinel"
+config:
+  operations:
+  - operation: "jq"
+    arguments:
+      key: ""
+      query: |
+        walk(
+          if type == "object" and has("kind") then
+              .source_kind = .kind | del(.kind)
+          else
+              .
+          end
+        ) | 
+        walk(
+          if type == "object" and has("uuid") then
+              .source_uuid = .uuid | del(.uuid)
+          else
+              .
+          end
+        ) |
+        walk(
+            if type == "object" and has("output") then
+                .source_output = .output | del(.output)
+            else
+                .
+            end
+        ) 
+        | 
+        walk(
+            if type == "object" and has("scan") then
+                .source_scan = .scan | del(.scan)
+            else
+                .
+            end
+        ) 
+        |
+        walk(
+            if type == "object" and has("id") then
+                .source_id = .id | del(.id)
+            else
+                .
+            end
+        ) 
+        |
+        walk(
+            if type == "object" and has("type") then
+                .source_type = .type | del(.type)
+            else
+                .
+            end
+        ) 

--- a/ocsf/v1.1.0/microsoft/microsoft-azure-sentinel.yaml
+++ b/ocsf/v1.1.0/microsoft/microsoft-azure-sentinel.yaml
@@ -2,38 +2,38 @@ name: "Microsoft Sentinel compliant schema"
 description: "Transforms incoming data's schema to rename Azure Sentinel reserved keywords. This transform is not guaranteed to contain all possible keywords preserved by Azure Sentinel."
 author: "Monad"
 contributors:
-- "https://github.com/mon-aneesh"
+  - "https://github.com/mon-aneesh"
 tags:
-- "v1.1.0"
-- "microsoft"
-- "azure"
-- "sentinel"
+  - "v1.1.0"
+  - "microsoft"
+  - "azure"
+  - "sentinel"
 config:
-  operations:
-  - operation: "jq"
-    arguments:
-      key: ""
-      query: |
-        if .kind then
-            .source_kind = .kind | del(.kind)
-        end
-        | 
-        if .type then
-            .source_type = .type | del(.type)
-        end
-        | 
-        if .uuid then
-            .source_uuid = .uuid | del(.uuid)
-        end
-        | 
-        if .output then
-            .source_output = .output | del(.output)
-        end
-        |
-        if .scan then
-            .source_scan = .scan | del(.scan)
-        end
-        |
-        if .id then
-            .source_id = .id | del(.id)
-        end
+    operations:
+      - operation: "jq"
+        arguments:
+            key: ""
+            query: |
+                if has("kind") then
+                    .source_kind = .kind | del(.kind)
+                end
+                | 
+                if has("type") then
+                    .source_type = .type | del(.type)
+                end
+                | 
+                if has("uuid") then
+                    .source_uuid = .uuid | del(.uuid)
+                end
+                | 
+                if has("output") then
+                    .source_output = .output | del(.output)
+                end
+                |
+                if has("scan") then
+                    .source_scan = .scan | del(.scan)
+                end
+                |
+                if has("id") then
+                    .source_id = .id | del(.id)
+                end


### PR DESCRIPTION
## Summary
- Adds transformation to rename Azure Sentinel reserved keywords in incoming data
- Handles reserved keywords: kind, uuid, output, scan, id, and type
- Transforms reserved fields by prefixing with "source_" and removing originals