### PR TITLE
moved avro and claud OTLP transforms since they are not OCSF transforms

### DIFF
--- a/utility/v1.0.0/anthropic/claude-otlp-flatten.yaml
+++ b/utility/v1.0.0/anthropic/claude-otlp-flatten.yaml
@@ -6,7 +6,7 @@ contributors:
 inputs:
   - "claude"
 tags:
-  - "v1.1.0"
+  - "v1.0.0"
   - "anthropic"
   - "claude"
   - "otel"

--- a/utility/v1.0.0/avro/avro-flatten.yaml
+++ b/utility/v1.0.0/avro/avro-flatten.yaml
@@ -6,7 +6,7 @@ contributors:
 inputs:
   - "salesforce-pubsub"
 tags:
-  - "v1.1.0"
+  - "v1.0.0"
   - "avro"
   - "salesforce"
 config:


### PR DESCRIPTION
There are 2 transforms that are not OCSF that live in the OCSF file path - moved them to their own utility file paths


NOTE: THIS WILL CREATE A DUPLICATE ENTRY. I have a PR comming to handle removals for the internal input that syncs the transforms.