### PR TITLE
fix(crowdstrike): conform vulnerabilities transform to OCSF v1.1.0 sc…

### DIFF
--- a/ocsf/v1.1.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
+++ b/ocsf/v1.1.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
@@ -3,6 +3,7 @@
   author: "Monad"
   contributors:
     - "https://github.com/Credgate"
+    - "https://github.com/behobu"
   inputs:
     - "crowdstrike-vulnerabilities"
   tags:
@@ -110,13 +111,7 @@
                 }
               ],
             
-              # Instead of using tostring, lets include a simplified version of raw data
-              "raw_data": {
-                "id": .id,
-                "vulnerability_id": .vulnerability_id,
-                "status": .status,
-                "timestamp": .created_timestamp
-              },
+              "raw_data": (. | tostring),
             
               # Metadata
               "metadata": {
@@ -126,7 +121,6 @@
                   "vendor_name": "Crowdstrike",
                   "version": "1.0"
                 },
-                "profiles": ["vulnerability"],
                 "uid": (.id // "UNKNOWN")
               },
             
@@ -166,13 +160,16 @@
                 ]
               },
             
-              # Cloud context if available
+              # Cloud context if available. Set to null when the source has no
+              # cloud provider info; the trailing pipeline drops the key
+              # entirely so the event doesn't falsely imply cloud-profile use.
               "cloud": (
-                if .host_info and .host_info.service_provider then {
-                  "provider": (.host_info.service_provider // "unknown"),
-                  "account_uid": (.host_info.service_provider_account_id // "unknown"),
-                  "instance_uid": (.host_info.instance_id // "unknown")
+                if .host_info.service_provider then {
+                  "provider": .host_info.service_provider,
+                  "account_uid": (.host_info.service_provider_account_id // ""),
+                  "instance_uid": (.host_info.instance_id // "")
                 } else null
                 end
               )
             }
+            | if .cloud == null then del(.cloud) else . end


### PR DESCRIPTION
…hema

Three corrections to the CrowdStrike Vulnerability Findings transform, each verified against three synthetic Spotlight records covering HIGH/LOW severity and mixed SUCCESS/FAILURE evaluation_logic outcomes.

* raw_data: emit as string (jq `. | tostring`) instead of an object literal. OCSF v1.1.0 specifies raw_data as string_t; downstream JSON-schema validators reject the object form. Matches the convention used in okta-systemlog, crowdstrike-device-details, and the other transforms in this repo.

* metadata.profiles: remove `["vulnerability"]`. There is no OCSF profile named "vulnerability" — the valid profiles for the Vulnerability Finding class are cloud, datetime, host, container, and linux/linux_users. Declaring an unknown profile gives downstream consumers a false signal about which cross-class attribute groups apply. The class is already self-identified via class_uid 2002.

* cloud: omit the key entirely when host_info.service_provider is absent, rather than emitting `cloud: null`. The null form implicitly opts into the cloud profile (cloud is profile-scoped) and conflicts with what the transform actually sources. Uses a trailing `del(.cloud)` pass because `empty` inside an object literal collapses the whole object in jq.

Also adds behobu to contributors per the repo's attribution rules.