### PR TITLE
feat(crowdstrike): add v1.3.0 vulnerabilities transform

### DIFF
--- a/ocsf/v1.3.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
+++ b/ocsf/v1.3.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
@@ -1,0 +1,184 @@
+  name: "CrowdStrike Vulnerability Findings to OCSF"
+  description: "Transforms CrowdStrike Vulnerability Findings data into OCSF v1.3.0 Schema"
+  author: "https://github.com/behobu"
+  contributors:
+    - "https://github.com/behobu"
+  inputs:
+    - "crowdstrike-vulnerabilities"
+  tags:
+    - "v1.3.0"
+    - "ocsf"
+    - "crowdstrike"
+    - "vulnerability"
+    - "findings"
+  config:
+    operations:
+      - operation: "jq"
+        arguments:
+          key: ""
+          query: |
+            def safe_timestamp:
+              if . and (. | type) == "string" then (. | fromdateiso8601) else null end;
+
+            def severity_to_id:
+              if . == "CRITICAL" then 5
+              elif . == "HIGH" then 4
+              elif . == "MEDIUM" then 3
+              elif . == "LOW" then 2
+              else 99
+              end;
+
+            def status_to_id:
+              if . == "open" then 1
+              elif . == "closed" then 2
+              elif . == "in_progress" then 3
+              else 99
+              end;
+
+            def build_resource:
+              {
+                "type": "host",
+                "name": (.host_info.hostname // "unknown"),
+                "uid": (.aid // "unknown"),
+                "criticality": (.host_info.asset_criticality // "Unassigned"),
+                "group": {
+                  "name": (
+                    if .host_info.groups and (.host_info.groups | type) == "array" then
+                      (.host_info.groups | join(", "))
+                    else ""
+                    end
+                  )
+                },
+                "labels": [
+                  (.host_info.os_version // "unknown"),
+                  (.host_info.platform // "unknown"),
+                  (.host_info.product_type_desc // "unknown")
+                ]
+              };
+
+            {
+              "activity_id": 1,
+              "category_uid": 2,
+              "class_uid": 2002,
+              "type_uid": 200201,
+
+              "time": (.created_timestamp | safe_timestamp),
+
+              "severity_id": ((.cve.severity // "UNKNOWN") | severity_to_id),
+              "severity": (.cve.severity // "UNKNOWN"),
+
+              "finding_info": {
+                "title": (.vulnerability_id // "UNKNOWN"),
+                "uid": (.id // "UNKNOWN"),
+                "desc": (.cve.description // "No description available"),
+                "created_time": (.created_timestamp | safe_timestamp),
+                "modified_time": (.updated_timestamp | safe_timestamp)
+              },
+
+              "vulnerabilities": [
+                {
+                  "title": (.vulnerability_id // "UNKNOWN"),
+                  "desc": (.cve.description // "No description available"),
+                  "severity": (.cve.severity // "UNKNOWN"),
+                  "cve": {
+                    "uid": (.vulnerability_id // "UNKNOWN"),
+                    "desc": (.cve.description // "No description available"),
+                    "cvss": [
+                      {
+                        "version": "3.1",
+                        "base_score": (.cve.base_score // 0),
+                        "vector_string": (.cve.vector // "UNKNOWN")
+                      }
+                    ],
+                    "references": (.cve.references // []),
+                    "modified_time": (.updated_timestamp | safe_timestamp)
+                  },
+                  "remediation": {
+                    "desc": (
+                      if .remediation and .remediation.entities then
+                        (.remediation.entities | map(.action) | join("; "))
+                      else ""
+                      end
+                    ),
+                    "references": (
+                      if .remediation and .remediation.entities then
+                        (.remediation.entities | map(.link) | map(select(length > 0)))
+                      else []
+                      end
+                    ),
+                    "kb_articles": (
+                      if .remediation and .remediation.entities then
+                        (.remediation.entities | map(.reference) | map(select(length > 0)))
+                      else []
+                      end
+                    )
+                  },
+                  "first_seen_time": (.created_timestamp | safe_timestamp),
+                  "last_seen_time": (.updated_timestamp | safe_timestamp),
+                  "is_exploit_available": false
+                }
+              ],
+
+              "observables": ([
+                (if .vulnerability_id then {
+                  "name": "cve.uid",
+                  "type": "CVE Object: uid",
+                  "type_id": 18,
+                  "value": .vulnerability_id
+                } else empty end),
+                (if .host_info.hostname then {
+                  "name": "device.hostname",
+                  "type": "Hostname",
+                  "type_id": 1,
+                  "value": .host_info.hostname
+                } else empty end),
+                (if .host_info.local_ip then {
+                  "name": "device.ip",
+                  "type": "IP Address",
+                  "type_id": 2,
+                  "value": .host_info.local_ip
+                } else empty end)
+              ]),
+
+              "raw_data": (. | tostring),
+
+              "metadata": {
+                "version": "1.3.0",
+                "product": {
+                  "name": "Crowdstrike Spotlight",
+                  "vendor_name": "Crowdstrike",
+                  "version": "1.0"
+                },
+                "uid": (.id // "UNKNOWN")
+              },
+
+              "confidence": (.confidence // "UNKNOWN"),
+              "confidence_id": (
+                if .confidence == "confirmed" then 2
+                elif .confidence == "high" then 2
+                elif .confidence == "medium" then 1
+                elif .confidence == "low" then 0
+                else 99
+                end
+              ),
+
+              "status": (.status // "unknown"),
+              "status_id": ((.status // "unknown") | status_to_id),
+
+              "resource": build_resource,
+
+              # New in v1.3.0 (recommended): resources array. Same host, exposed
+              # under both the singular `resource` (backward compat) and the
+              # plural array form preferred by tools written against 1.3.0+.
+              "resources": [build_resource],
+
+              "cloud": (
+                if .host_info.service_provider then {
+                  "provider": .host_info.service_provider,
+                  "account_uid": (.host_info.service_provider_account_id // ""),
+                  "instance_uid": (.host_info.instance_id // "")
+                } else null
+                end
+              )
+            }
+            | if .cloud == null then del(.cloud) else . end


### PR DESCRIPTION
Adds ocsf/v1.3.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml, targeting OCSF v1.3.0's Vulnerability Finding class (uid 2002).

Builds on the v1.2.0 mapping with the structural fixes already in place (raw_data as string, no profiles claim, cloud omitted when absent in source).

Carries forward the v1.2.0 `observables` array (CVE + hostname + IP).

Adds the v1.3.0-recommended `resources` array — the plural-array form of resource_details preferred by tools written against 1.3.0+. The same host data is exposed under both the legacy singular `resource` field (backward compat for downstream consumers that haven't moved) and the new `resources` array. A small build_resource helper avoids duplicating the object literal.

Skips status_code / status_detail (no equivalent in source).

Validated against three synthetic Spotlight records covering HIGH/LOW severity and mixed SUCCESS/FAILURE evaluation_logic outcomes; validator reports no missing-required and no unknown top-level keys.