### PR TITLE
feat(crowdstrike): add v1.4.0 vulnerabilities transform

### DIFF
--- a/ocsf/v1.4.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
+++ b/ocsf/v1.4.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
@@ -1,0 +1,224 @@
+  name: "CrowdStrike Vulnerability Findings to OCSF"
+  description: "Transforms CrowdStrike Vulnerability Findings data into OCSF v1.4.0 Schema"
+  author: "https://github.com/behobu"
+  contributors:
+    - "https://github.com/behobu"
+  inputs:
+    - "crowdstrike-vulnerabilities"
+  tags:
+    - "v1.4.0"
+    - "ocsf"
+    - "crowdstrike"
+    - "vulnerability"
+    - "findings"
+  config:
+    operations:
+      - operation: "jq"
+        arguments:
+          key: ""
+          query: |
+            def safe_timestamp:
+              if . and (. | type) == "string" then (. | fromdateiso8601) else null end;
+
+            def severity_to_id:
+              if . == "CRITICAL" then 5
+              elif . == "HIGH" then 4
+              elif . == "MEDIUM" then 3
+              elif . == "LOW" then 2
+              else 99
+              end;
+
+            def status_to_id:
+              if . == "open" then 1
+              elif . == "closed" then 2
+              elif . == "in_progress" then 3
+              else 99
+              end;
+
+            # OCSF device.type_id: 1=Server, 2=Desktop, 3=Laptop, 4=Tablet,
+            # 5=Mobile, 6=Virtual. CrowdStrike product_type_desc carries
+            # "Workstation"/"Server"/"Mobile" — map accordingly.
+            def device_type_id:
+              if . == "Workstation" then 2
+              elif . == "Server" then 1
+              elif . == "Laptop" then 3
+              elif . == "Mobile" then 5
+              else 0
+              end;
+
+            # OCSF os.type_id: 100=Windows, 200=Linux, 300=macOS, 201=Android,
+            # 301=iOS, 99=Other.
+            def os_type_id:
+              if . == "Windows" then 100
+              elif . == "Linux" then 200
+              elif . == "Mac" or . == "macOS" then 300
+              elif . == "Android" then 201
+              elif . == "iOS" then 301
+              else 99
+              end;
+
+            def build_resource:
+              {
+                "type": "host",
+                "name": (.host_info.hostname // "unknown"),
+                "uid": (.aid // "unknown"),
+                "criticality": (.host_info.asset_criticality // "Unassigned"),
+                "group": {
+                  "name": (
+                    if .host_info.groups and (.host_info.groups | type) == "array" then
+                      (.host_info.groups | join(", "))
+                    else ""
+                    end
+                  )
+                },
+                "labels": [
+                  (.host_info.os_version // "unknown"),
+                  (.host_info.platform // "unknown"),
+                  (.host_info.product_type_desc // "unknown")
+                ]
+              };
+
+            {
+              "activity_id": 1,
+              "category_uid": 2,
+              "class_uid": 2002,
+              "type_uid": 200201,
+
+              "time": (.created_timestamp | safe_timestamp),
+
+              "severity_id": ((.cve.severity // "UNKNOWN") | severity_to_id),
+              "severity": (.cve.severity // "UNKNOWN"),
+
+              "finding_info": {
+                "title": (.vulnerability_id // "UNKNOWN"),
+                "uid": (.id // "UNKNOWN"),
+                "desc": (.cve.description // "No description available"),
+                "created_time": (.created_timestamp | safe_timestamp),
+                "modified_time": (.updated_timestamp | safe_timestamp)
+              },
+
+              "vulnerabilities": [
+                {
+                  "title": (.vulnerability_id // "UNKNOWN"),
+                  "desc": (.cve.description // "No description available"),
+                  "severity": (.cve.severity // "UNKNOWN"),
+                  "cve": {
+                    "uid": (.vulnerability_id // "UNKNOWN"),
+                    "desc": (.cve.description // "No description available"),
+                    "cvss": [
+                      {
+                        "version": "3.1",
+                        "base_score": (.cve.base_score // 0),
+                        "vector_string": (.cve.vector // "UNKNOWN")
+                      }
+                    ],
+                    "references": (.cve.references // []),
+                    "modified_time": (.updated_timestamp | safe_timestamp)
+                  },
+                  "remediation": {
+                    "desc": (
+                      if .remediation and .remediation.entities then
+                        (.remediation.entities | map(.action) | join("; "))
+                      else ""
+                      end
+                    ),
+                    "references": (
+                      if .remediation and .remediation.entities then
+                        (.remediation.entities | map(.link) | map(select(length > 0)))
+                      else []
+                      end
+                    ),
+                    "kb_articles": (
+                      if .remediation and .remediation.entities then
+                        (.remediation.entities | map(.reference) | map(select(length > 0)))
+                      else []
+                      end
+                    )
+                  },
+                  "first_seen_time": (.created_timestamp | safe_timestamp),
+                  "last_seen_time": (.updated_timestamp | safe_timestamp),
+                  "is_exploit_available": false
+                }
+              ],
+
+              "observables": ([
+                (if .vulnerability_id then {
+                  "name": "cve.uid",
+                  "type": "CVE Object: uid",
+                  "type_id": 18,
+                  "value": .vulnerability_id
+                } else empty end),
+                (if .host_info.hostname then {
+                  "name": "device.hostname",
+                  "type": "Hostname",
+                  "type_id": 1,
+                  "value": .host_info.hostname
+                } else empty end),
+                (if .host_info.local_ip then {
+                  "name": "device.ip",
+                  "type": "IP Address",
+                  "type_id": 2,
+                  "value": .host_info.local_ip
+                } else empty end)
+              ]),
+
+              "raw_data": (. | tostring),
+
+              "metadata": {
+                "version": "1.4.0",
+                "product": {
+                  "name": "Crowdstrike Spotlight",
+                  "vendor_name": "Crowdstrike",
+                  "version": "1.0"
+                },
+                "uid": (.id // "UNKNOWN")
+              },
+
+              "confidence": (.confidence // "UNKNOWN"),
+              "confidence_id": (
+                if .confidence == "confirmed" then 2
+                elif .confidence == "high" then 2
+                elif .confidence == "medium" then 1
+                elif .confidence == "low" then 0
+                else 99
+                end
+              ),
+
+              "status": (.status // "unknown"),
+              "status_id": ((.status // "unknown") | status_to_id),
+
+              "resource": build_resource,
+              "resources": [build_resource],
+
+              # New in v1.4.0: `device` is a base-level recommended attribute
+              # (previously host-profile-scoped). CrowdStrike's host_info
+              # carries enough to populate a real OCSF Device object with a
+              # nested OS object — meaningfully richer than the generic
+              # `resource` field.
+              "device": {
+                "type_id": (.host_info.product_type_desc // "" | device_type_id),
+                "type": (.host_info.product_type_desc // ""),
+                "hostname": (.host_info.hostname // ""),
+                "uid": (.aid // ""),
+                "ip": (.host_info.local_ip // ""),
+                "domain": (.host_info.machine_domain // ""),
+                "vendor_name": (.host_info.system_manufacturer // ""),
+                "os": {
+                  "name": ((.host_info.platform // "") + " " + (.host_info.os_version // "") | gsub("^\\s+|\\s+$"; "")),
+                  "type_id": (.host_info.platform // "" | os_type_id),
+                  "type": (.host_info.platform // ""),
+                  "version": (.host_info.os_version // ""),
+                  "build": (.host_info.os_build // "")
+                }
+              },
+
+              "cloud": (
+                if .host_info.service_provider then {
+                  "provider": .host_info.service_provider,
+                  "account_uid": (.host_info.service_provider_account_id // ""),
+                  "instance_uid": (.host_info.instance_id // "")
+                } else null
+                end
+              )
+            }
+            | if .cloud == null then del(.cloud) else . end


### PR DESCRIPTION
Adds ocsf/v1.4.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml, targeting OCSF v1.4.0's Vulnerability Finding class (uid 2002).

Builds on the v1.3.0 mapping. Structural fixes (raw_data as string, no profiles claim, cloud omitted when absent) baked in from the start. Carries forward `observables` (v1.2.0) and the `resources` array form (v1.3.0).

The notable v1.4.0 addition: a proper `device` object populated from CrowdStrike's host_info. In 1.4.0 `device` moved from being a host-profile attribute into the base recommended set, so this can be populated without claiming any profile. Fields covered:

  * device.type_id        from product_type_desc (Workstation -> 2 Desktop,
                          Server -> 1, Laptop -> 3, Mobile -> 5)
  * device.hostname/uid   from host_info.hostname / aid
  * device.ip             from host_info.local_ip
  * device.domain         from host_info.machine_domain
  * device.vendor_name    from host_info.system_manufacturer
  * device.os.name/type_id from platform + os_version (Windows -> 100,
                          Linux -> 200, macOS -> 300, etc)
  * device.os.version/build from os_version / os_build

This is meaningfully richer than the generic `resource` field for downstream consumers — proper device identity, OS family, and version. The legacy `resource` and v1.3.0 `resources` array are kept alongside for backward compatibility.

Skips status_code / status_detail (no equivalent in source).

Validated against three synthetic Spotlight records covering HIGH/LOW severity and mixed SUCCESS/FAILURE evaluation_logic outcomes; validator reports no missing-required and no unknown top-level keys.