### PR TITLE
chore(crowdstrike): include OCSF version in vulnerabilities transform names

### DIFF
--- a/ocsf/v1.1.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
+++ b/ocsf/v1.1.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
@@ -1,5 +1,5 @@
-  name: "CrowdStrike Vulnerability Findings to OCSF"
-  description: "Transforms CrowdStrike Vulnerability Findings data into OCSF Schema"
+  name: "CrowdStrike Vulnerability Findings to OCSF v1.1.0"
+  description: "Transforms CrowdStrike Vulnerability Findings data into OCSF v1.1.0 Schema"
   author: "Monad"
   contributors:
     - "https://github.com/Credgate"

--- a/ocsf/v1.2.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
+++ b/ocsf/v1.2.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
@@ -1,4 +1,4 @@
-  name: "CrowdStrike Vulnerability Findings to OCSF"
+  name: "CrowdStrike Vulnerability Findings to OCSF v1.2.0"
   description: "Transforms CrowdStrike Vulnerability Findings data into OCSF v1.2.0 Schema"
   author: "https://github.com/behobu"
   contributors:

--- a/ocsf/v1.3.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
+++ b/ocsf/v1.3.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
@@ -1,4 +1,4 @@
-  name: "CrowdStrike Vulnerability Findings to OCSF"
+  name: "CrowdStrike Vulnerability Findings to OCSF v1.3.0"
   description: "Transforms CrowdStrike Vulnerability Findings data into OCSF v1.3.0 Schema"
   author: "https://github.com/behobu"
   contributors:

--- a/ocsf/v1.4.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
+++ b/ocsf/v1.4.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
@@ -1,4 +1,4 @@
-  name: "CrowdStrike Vulnerability Findings to OCSF"
+  name: "CrowdStrike Vulnerability Findings to OCSF v1.4.0"
   description: "Transforms CrowdStrike Vulnerability Findings data into OCSF v1.4.0 Schema"
   author: "https://github.com/behobu"
   contributors:

--- a/ocsf/v1.5.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
+++ b/ocsf/v1.5.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml
@@ -1,4 +1,4 @@
-  name: "CrowdStrike Vulnerability Findings to OCSF"
+  name: "CrowdStrike Vulnerability Findings to OCSF v1.5.0"
   description: "Transforms CrowdStrike Vulnerability Findings data into OCSF v1.5.0 Schema"
   author: "https://github.com/behobu"
   contributors:


### PR DESCRIPTION
## Summary
- Suffix the `name` field on all five CrowdStrike Vulnerability Findings transforms (`ocsf/v1.1.0` → `ocsf/v1.5.0`) with the OCSF version they target — e.g. `CrowdStrike Vulnerability Findings to OCSF v1.4.0` — so they no longer collide in the Monad SaaS UI after the per-version transforms landed (PRs #19–#23).
- Normalize the v1.1.0 file's `description` (previously `…into OCSF Schema`) to match v1.2.0–v1.5.0: `…into OCSF v1.1.0 Schema`.
- No transform logic, inputs, tags, or outputs are touched.

## Motivation
PRs #19–#23 published per-version CrowdStrike Vulnerability Findings transforms (one each for OCSF v1.1.0 through v1.5.0). Each transform's `name` was identical, so once the hourly sync surfaced them in the Monad app, users couldn't tell which one targeted which OCSF version. Embedding `v1.X.0` in the display name resolves the ambiguity.

## Test plan
- [ ] Confirm the diff is limited to the five `ocsf/v1.X.0/crowdstrike/edr/crowdstrike-vulnerabilities.yaml` files and only edits `name` (plus the v1.1.0 `description`).
- [ ] After merge, verify the next hourly sync surfaces five distinct transform names in the Monad UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)