### PR TITLE
feat(crowdstrike): add activity-logs transform for OCSF v1.0.0–v1.5.0

### DIFF
--- a/ocsf/v1.0.0/crowdstrike/crowdstrike-activity-logs.yaml
+++ b/ocsf/v1.0.0/crowdstrike/crowdstrike-activity-logs.yaml
@@ -1,0 +1,65 @@
+name: "CrowdStrike Activity Logs to OCSF v1.0.0"
+description: "Transforms CrowdStrike Activity Logs (per-device recent login records) into the OCSF v1.0.0 Authentication class. Emits one event per login in the source record's recent_logins array."
+author: "https://github.com/behobu"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-activity-logs"
+tags:
+  - "v1.0.0"
+  - "ocsf"
+  - "crowdstrike"
+  - "iam"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # OCSF Authentication (class_uid=3002) — v1.0.0
+          # Input: one CrowdStrike Activity Logs record per invocation.
+          # The record is per-device and carries a recent_logins array;
+          # this transform emits ONE OCSF Authentication event per login.
+          #
+          # v1.0.0 Authentication has the same base required/recommended
+          # field set as v1.1.0, so this transform is a metadata.version
+          # bump of the v1.1.0 mapping.
+          # ---------------------------------------------------------------
+
+          def to_epoch($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then $ts
+            else ($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601)
+            end;
+
+          . as $root
+          | (.recent_logins // [])[]
+          | select(.login_time != null and .login_time != "")
+          | {
+              category_uid: 3,
+              class_uid:    3002,
+              type_uid:     300201,
+              activity_id:  1,
+              severity_id:  1,
+              status_id:    1,
+              time:         to_epoch(.login_time),
+              metadata: ({
+                version: "1.0.0",
+                product: {
+                  vendor_name: "CrowdStrike",
+                  name: "Falcon"
+                },
+                tenant_uid: $root.cid
+              } | if .tenant_uid == null then del(.tenant_uid) else . end),
+              user: ({
+                type_id: 1,
+                name: .user_name
+              } | if .name == null then del(.name) else . end),
+              dst_endpoint: ({
+                uid: $root.device_id
+              } | if .uid == null then null else . end),
+              raw_data: (. | tostring)
+            }
+          | if .dst_endpoint == null then del(.dst_endpoint) else . end

--- a/ocsf/v1.1.0/crowdstrike/crowdstrike-activity-logs.yaml
+++ b/ocsf/v1.1.0/crowdstrike/crowdstrike-activity-logs.yaml
@@ -1,0 +1,61 @@
+name: "CrowdStrike Activity Logs to OCSF v1.1.0"
+description: "Transforms CrowdStrike Activity Logs (per-device recent login records) into the OCSF v1.1.0 Authentication class. Emits one event per login in the source record's recent_logins array."
+author: "https://github.com/behobu"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-activity-logs"
+tags:
+  - "v1.1.0"
+  - "ocsf"
+  - "crowdstrike"
+  - "iam"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # OCSF Authentication (class_uid=3002) — v1.1.0
+          # Input: one CrowdStrike Activity Logs record per invocation.
+          # The record is per-device and carries a recent_logins array;
+          # this transform emits ONE OCSF Authentication event per login.
+          # ---------------------------------------------------------------
+
+          def to_epoch($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then $ts
+            else ($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601)
+            end;
+
+          . as $root
+          | (.recent_logins // [])[]
+          | select(.login_time != null and .login_time != "")
+          | {
+              category_uid: 3,
+              class_uid:    3002,
+              type_uid:     300201,
+              activity_id:  1,
+              severity_id:  1,
+              status_id:    1,
+              time:         to_epoch(.login_time),
+              metadata: ({
+                version: "1.1.0",
+                product: {
+                  vendor_name: "CrowdStrike",
+                  name: "Falcon"
+                },
+                tenant_uid: $root.cid
+              } | if .tenant_uid == null then del(.tenant_uid) else . end),
+              user: ({
+                type_id: 1,
+                name: .user_name
+              } | if .name == null then del(.name) else . end),
+              dst_endpoint: ({
+                uid: $root.device_id
+              } | if .uid == null then null else . end),
+              raw_data: (. | tostring)
+            }
+          | if .dst_endpoint == null then del(.dst_endpoint) else . end

--- a/ocsf/v1.2.0/crowdstrike/crowdstrike-activity-logs.yaml
+++ b/ocsf/v1.2.0/crowdstrike/crowdstrike-activity-logs.yaml
@@ -1,0 +1,79 @@
+name: "CrowdStrike Activity Logs to OCSF v1.2.0"
+description: "Transforms CrowdStrike Activity Logs (per-device recent login records) into the OCSF v1.2.0 Authentication class. Emits one event per login in the source record's recent_logins array."
+author: "https://github.com/behobu"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-activity-logs"
+tags:
+  - "v1.2.0"
+  - "ocsf"
+  - "crowdstrike"
+  - "iam"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # OCSF Authentication (class_uid=3002) — v1.2.0
+          # Input: one CrowdStrike Activity Logs record per invocation.
+          # The record is per-device and carries a recent_logins array;
+          # this transform emits ONE OCSF Authentication event per login.
+          #
+          # Carries forward from v1.1.0 the base mapping, and adds the
+          # v1.2.0-recommended `observables` array, populated from the
+          # two natural pivots the source provides:
+          #   * type_id  4 (User Name)    from recent_logins[].user_name
+          #   * type_id 10 (Resource UID) from .device_id
+          # ---------------------------------------------------------------
+
+          def to_epoch($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then $ts
+            else ($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601)
+            end;
+
+          . as $root
+          | (.recent_logins // [])[]
+          | . as $login
+          | select(.login_time != null and .login_time != "")
+          | {
+              category_uid: 3,
+              class_uid:    3002,
+              type_uid:     300201,
+              activity_id:  1,
+              severity_id:  1,
+              status_id:    1,
+              time:         to_epoch(.login_time),
+              metadata: ({
+                version: "1.2.0",
+                product: {
+                  vendor_name: "CrowdStrike",
+                  name: "Falcon"
+                },
+                tenant_uid: $root.cid
+              } | if .tenant_uid == null then del(.tenant_uid) else . end),
+              user: ({
+                type_id: 1,
+                name: .user_name
+              } | if .name == null then del(.name) else . end),
+              dst_endpoint: ({
+                uid: $root.device_id
+              } | if .uid == null then null else . end),
+              observables: (
+                [
+                  (if $login.user_name != null and $login.user_name != ""
+                   then {name: "user.name", type_id: 4, value: $login.user_name}
+                   else empty end),
+                  (if $root.device_id != null and $root.device_id != ""
+                   then {name: "dst_endpoint.uid", type_id: 10, value: $root.device_id}
+                   else empty end)
+                ]
+              ),
+              raw_data: (. | tostring)
+            }
+          | if .dst_endpoint == null then del(.dst_endpoint) else . end
+          | if (.observables | length) == 0 then del(.observables) else . end

--- a/ocsf/v1.3.0/crowdstrike/crowdstrike-activity-logs.yaml
+++ b/ocsf/v1.3.0/crowdstrike/crowdstrike-activity-logs.yaml
@@ -1,0 +1,79 @@
+name: "CrowdStrike Activity Logs to OCSF v1.3.0"
+description: "Transforms CrowdStrike Activity Logs (per-device recent login records) into the OCSF v1.3.0 Authentication class. Emits one event per login in the source record's recent_logins array."
+author: "https://github.com/behobu"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-activity-logs"
+tags:
+  - "v1.3.0"
+  - "ocsf"
+  - "crowdstrike"
+  - "iam"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # OCSF Authentication (class_uid=3002) — v1.3.0
+          # Input: one CrowdStrike Activity Logs record per invocation.
+          # The record is per-device and carries a recent_logins array;
+          # this transform emits ONE OCSF Authentication event per login.
+          #
+          # Carries forward from v1.1.0 the base mapping, and adds the
+          # v1.3.0-recommended `observables` array, populated from the
+          # two natural pivots the source provides:
+          #   * type_id  4 (User Name)    from recent_logins[].user_name
+          #   * type_id 10 (Resource UID) from .device_id
+          # ---------------------------------------------------------------
+
+          def to_epoch($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then $ts
+            else ($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601)
+            end;
+
+          . as $root
+          | (.recent_logins // [])[]
+          | . as $login
+          | select(.login_time != null and .login_time != "")
+          | {
+              category_uid: 3,
+              class_uid:    3002,
+              type_uid:     300201,
+              activity_id:  1,
+              severity_id:  1,
+              status_id:    1,
+              time:         to_epoch(.login_time),
+              metadata: ({
+                version: "1.3.0",
+                product: {
+                  vendor_name: "CrowdStrike",
+                  name: "Falcon"
+                },
+                tenant_uid: $root.cid
+              } | if .tenant_uid == null then del(.tenant_uid) else . end),
+              user: ({
+                type_id: 1,
+                name: .user_name
+              } | if .name == null then del(.name) else . end),
+              dst_endpoint: ({
+                uid: $root.device_id
+              } | if .uid == null then null else . end),
+              observables: (
+                [
+                  (if $login.user_name != null and $login.user_name != ""
+                   then {name: "user.name", type_id: 4, value: $login.user_name}
+                   else empty end),
+                  (if $root.device_id != null and $root.device_id != ""
+                   then {name: "dst_endpoint.uid", type_id: 10, value: $root.device_id}
+                   else empty end)
+                ]
+              ),
+              raw_data: (. | tostring)
+            }
+          | if .dst_endpoint == null then del(.dst_endpoint) else . end
+          | if (.observables | length) == 0 then del(.observables) else . end

--- a/ocsf/v1.4.0/crowdstrike/crowdstrike-activity-logs.yaml
+++ b/ocsf/v1.4.0/crowdstrike/crowdstrike-activity-logs.yaml
@@ -1,0 +1,79 @@
+name: "CrowdStrike Activity Logs to OCSF v1.4.0"
+description: "Transforms CrowdStrike Activity Logs (per-device recent login records) into the OCSF v1.4.0 Authentication class. Emits one event per login in the source record's recent_logins array."
+author: "https://github.com/behobu"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-activity-logs"
+tags:
+  - "v1.4.0"
+  - "ocsf"
+  - "crowdstrike"
+  - "iam"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # OCSF Authentication (class_uid=3002) — v1.4.0
+          # Input: one CrowdStrike Activity Logs record per invocation.
+          # The record is per-device and carries a recent_logins array;
+          # this transform emits ONE OCSF Authentication event per login.
+          #
+          # Carries forward from v1.1.0 the base mapping, and adds the
+          # v1.4.0-recommended `observables` array, populated from the
+          # two natural pivots the source provides:
+          #   * type_id  4 (User Name)    from recent_logins[].user_name
+          #   * type_id 10 (Resource UID) from .device_id
+          # ---------------------------------------------------------------
+
+          def to_epoch($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then $ts
+            else ($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601)
+            end;
+
+          . as $root
+          | (.recent_logins // [])[]
+          | . as $login
+          | select(.login_time != null and .login_time != "")
+          | {
+              category_uid: 3,
+              class_uid:    3002,
+              type_uid:     300201,
+              activity_id:  1,
+              severity_id:  1,
+              status_id:    1,
+              time:         to_epoch(.login_time),
+              metadata: ({
+                version: "1.4.0",
+                product: {
+                  vendor_name: "CrowdStrike",
+                  name: "Falcon"
+                },
+                tenant_uid: $root.cid
+              } | if .tenant_uid == null then del(.tenant_uid) else . end),
+              user: ({
+                type_id: 1,
+                name: .user_name
+              } | if .name == null then del(.name) else . end),
+              dst_endpoint: ({
+                uid: $root.device_id
+              } | if .uid == null then null else . end),
+              observables: (
+                [
+                  (if $login.user_name != null and $login.user_name != ""
+                   then {name: "user.name", type_id: 4, value: $login.user_name}
+                   else empty end),
+                  (if $root.device_id != null and $root.device_id != ""
+                   then {name: "dst_endpoint.uid", type_id: 10, value: $root.device_id}
+                   else empty end)
+                ]
+              ),
+              raw_data: (. | tostring)
+            }
+          | if .dst_endpoint == null then del(.dst_endpoint) else . end
+          | if (.observables | length) == 0 then del(.observables) else . end

--- a/ocsf/v1.5.0/crowdstrike/crowdstrike-activity-logs.yaml
+++ b/ocsf/v1.5.0/crowdstrike/crowdstrike-activity-logs.yaml
@@ -1,0 +1,79 @@
+name: "CrowdStrike Activity Logs to OCSF v1.5.0"
+description: "Transforms CrowdStrike Activity Logs (per-device recent login records) into the OCSF v1.5.0 Authentication class. Emits one event per login in the source record's recent_logins array."
+author: "https://github.com/behobu"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-activity-logs"
+tags:
+  - "v1.5.0"
+  - "ocsf"
+  - "crowdstrike"
+  - "iam"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # OCSF Authentication (class_uid=3002) — v1.5.0
+          # Input: one CrowdStrike Activity Logs record per invocation.
+          # The record is per-device and carries a recent_logins array;
+          # this transform emits ONE OCSF Authentication event per login.
+          #
+          # Carries forward from v1.1.0 the base mapping, and adds the
+          # v1.5.0-recommended `observables` array, populated from the
+          # two natural pivots the source provides:
+          #   * type_id  4 (User Name)    from recent_logins[].user_name
+          #   * type_id 10 (Resource UID) from .device_id
+          # ---------------------------------------------------------------
+
+          def to_epoch($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then $ts
+            else ($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601)
+            end;
+
+          . as $root
+          | (.recent_logins // [])[]
+          | . as $login
+          | select(.login_time != null and .login_time != "")
+          | {
+              category_uid: 3,
+              class_uid:    3002,
+              type_uid:     300201,
+              activity_id:  1,
+              severity_id:  1,
+              status_id:    1,
+              time:         to_epoch(.login_time),
+              metadata: ({
+                version: "1.5.0",
+                product: {
+                  vendor_name: "CrowdStrike",
+                  name: "Falcon"
+                },
+                tenant_uid: $root.cid
+              } | if .tenant_uid == null then del(.tenant_uid) else . end),
+              user: ({
+                type_id: 1,
+                name: .user_name
+              } | if .name == null then del(.name) else . end),
+              dst_endpoint: ({
+                uid: $root.device_id
+              } | if .uid == null then null else . end),
+              observables: (
+                [
+                  (if $login.user_name != null and $login.user_name != ""
+                   then {name: "user.name", type_id: 4, value: $login.user_name}
+                   else empty end),
+                  (if $root.device_id != null and $root.device_id != ""
+                   then {name: "dst_endpoint.uid", type_id: 10, value: $root.device_id}
+                   else empty end)
+                ]
+              ),
+              raw_data: (. | tostring)
+            }
+          | if .dst_endpoint == null then del(.dst_endpoint) else . end
+          | if (.observables | length) == 0 then del(.observables) else . end


### PR DESCRIPTION
## Summary
Adds six new transforms — one per published OCSF version — that map the **CrowdStrike Activity Logs** source (per-device records carrying a `recent_logins` array) to the OCSF **Authentication** class (`class_uid` 3002, IAM category).

Each input record emits **one OCSF Authentication event per entry in `recent_logins`**, so a device with N recent logins produces N events. Records with `recent_logins: []` (or the key absent) emit nothing.

## Files added

| OCSF version | Path |
|---|---|
| v1.0.0 | `ocsf/v1.0.0/crowdstrike/crowdstrike-activity-logs.yaml` |
| v1.1.0 | `ocsf/v1.1.0/crowdstrike/crowdstrike-activity-logs.yaml` |
| v1.2.0 | `ocsf/v1.2.0/crowdstrike/crowdstrike-activity-logs.yaml` |
| v1.3.0 | `ocsf/v1.3.0/crowdstrike/crowdstrike-activity-logs.yaml` |
| v1.4.0 | `ocsf/v1.4.0/crowdstrike/crowdstrike-activity-logs.yaml` |
| v1.5.0 | `ocsf/v1.5.0/crowdstrike/crowdstrike-activity-logs.yaml` |

> Note: v1.0.0 is a brand-new directory in this repo — no transforms had been contributed at v1.0.0 previously.

## Per-event mapping

| OCSF field | Source | Notes |
|---|---|---|
| `category_uid` / `class_uid` / `type_uid` | constants | 3 / 3002 / 300201 |
| `activity_id` | `1` (Logon) | source carries no logoff or failure indicator |
| `severity_id` | `1` (Informational) | routine logon |
| `status_id` | `1` (Success) | same reasoning |
| `time` | `recent_logins[].login_time` | ISO-8601 → epoch (fractional seconds stripped) |
| `user.type_id` / `user.name` | `1` / `recent_logins[].user_name` | `name` is omitted when absent |
| `dst_endpoint.uid` | parent `.device_id` | the host being logged into; whole object dropped if missing |
| `metadata.product` | `{vendor_name: "CrowdStrike", name: "Falcon"}` | required |
| `metadata.tenant_uid` | parent `.cid` | CrowdStrike Customer ID |
| `metadata.version` | per-target-version | `"1.0.0"`, `"1.1.0"`, …, `"1.5.0"` |
| `raw_data` | per-login sub-record stringified | community-transformations convention |

## Per-version structural notes

- **v1.0.0 / v1.1.0** — Authentication's base required+recommended set is identical between these versions, so v1.0.0 is a pure `metadata.version` back-port of the v1.1.0 mapping.
- **v1.2.0** — adds the v1.2.0-recommended `observables` array, populated with the two natural pivots the source carries:
  - `type_id 4` (User Name) ← `recent_logins[].user_name`
  - `type_id 10` (Resource UID) ← `.device_id`
  Each observable is conditionally included; missing source fields shorten the array rather than emit nulls.
- **v1.3.0 / v1.4.0 / v1.5.0** — base Authentication adds no further attributes the source could populate, so these carry the v1.2.0 body forward with only the version, tag, and `metadata.version` bumped.

## Recommended fields deliberately skipped (every version)

`auth_protocol_id`, `logon_type_id`, `is_remote`, `message`, `service`, `timezone_offset`, `certificate`, `is_mfa`, `session`, `src_endpoint`, `status_code`, `status_detail`, `actor` (v1.4.0+). The CrowdStrike Recent Login Details source carries no equivalent signal — empty / null placeholders would mislead downstream consumers.

No profile claims (cloud / host / container / datetime / security_control); the source data can't populate any profile's required fields.

## Validation

Validated each transform against four synthetic records:
1. Two happy-path records with two logins each.
2. An edge record with `recent_logins: []`.
3. A sparse record with the second login missing `user_name`.

`scripts/validate-against-ocsf.sh` reports **zero missing-required and zero unknown top-level keys** on every (version × sample) pairing. The empty record correctly emits no events; the sparse record's second event correctly omits `user.name` rather than emitting null.

## Test plan
- [ ] Confirm the diff is six new YAMLs only, no other files touched.
- [ ] After merge, verify the next hourly sync surfaces six distinct transform names in the Monad UI (each suffixed with its OCSF version, per the new naming convention).
- [ ] Spot-check one event end-to-end on a real CrowdStrike Activity Logs record in staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)