### PR TITLE
feat(tenable): map vulnerabilities to OCSF v1.1.0–v1.5.0

### DIFF
--- a/ocsf/v1.2.0/tenable/tenable-vulnerabilities.yaml
+++ b/ocsf/v1.2.0/tenable/tenable-vulnerabilities.yaml
@@ -1,13 +1,12 @@
-name: "Tenable Vulnerability Findings to OCSF v1.1.0"
-description: "Transforms Tenable Vulnerability Findings into the OCSF v1.1.0 Vulnerability Finding class."
+name: "Tenable Vulnerability Findings to OCSF v1.2.0"
+description: "Transforms Tenable Vulnerability Findings into the OCSF v1.2.0 Vulnerability Finding class."
 author: "Monad"
 contributors:
-  - "https://github.com/Credgate"
   - "https://github.com/behobu"
 inputs:
   - "tenable-vulnerabilities"
 tags:
-  - "v1.1.0"
+  - "v1.2.0"
   - "ocsf"
   - "tenable"
   - "vulnerability"
@@ -19,7 +18,7 @@ config:
         key: ""
         query: |
           # ---------------------------------------------------------------
-          # OCSF Vulnerability Finding (class_uid=2002) — v1.1.0
+          # OCSF Vulnerability Finding (class_uid=2002) — v1.2.0
           # Input: one Tenable VM vulnerability export record per invocation.
           # ---------------------------------------------------------------
 
@@ -62,7 +61,7 @@ config:
             {"version": $ver, "base_score": $score}
             + (if $vec != null then {"vector_string": $vec} else {} end);
 
-          # Shared inputs reused across the vulnerabilities array.
+          # Shared inputs reused across the vulnerabilities array and observables.
           (.plugin // {}) as $p |
           (.asset // {}) as $a |
           ($p.see_also // []) as $refs |
@@ -121,7 +120,7 @@ config:
 
             # --- Metadata (REQUIRED) ---
             "metadata": {
-              "version": "1.1.0",
+              "version": "1.2.0",
               "product": {
                 "vendor_name": "Tenable",
                 "name": "Tenable Vulnerability Management"
@@ -145,7 +144,7 @@ config:
 
             # --- Vulnerabilities (REQUIRED) ---
             # The OCSF `vulnerability` object carries an `at_least_one:
-            # [cve, cwe]` constraint in v1.1.0. Emit one entry per CVE; if a
+            # [cve, cwe]` constraint in v1.2.0. Emit one entry per CVE; if a
             # plugin reports no CVE, fall back to CWE. (The `advisory` object
             # used as a last resort in v1.4.0+ does not exist in this version,
             # so a record with neither a CVE nor a CWE cannot satisfy the
@@ -167,6 +166,17 @@ config:
               "uid": $a.uuid,
               "labels": ($a.operating_system // [])
             },
+
+            # --- Recommended: observables (new in v1.2.0; natural pivots) ---
+            "observables": [
+              ( $cves[]? | { "name": "vulnerabilities.cve.uid", "type": "CVE Object: uid", "type_id": 18, "value": . } ),
+              (if ($a.hostname // $a.fqdn) != null
+                then { "name": "device.hostname", "type": "Hostname", "type_id": 1, "value": ($a.hostname // $a.fqdn) } else empty end),
+              (if $a.ipv4 != null
+                then { "name": "device.ip", "type": "IP Address", "type_id": 2, "value": $a.ipv4 } else empty end),
+              (if $a.mac_address != null
+                then { "name": "device.mac", "type": "MAC Address", "type_id": 3, "value": $a.mac_address } else empty end)
+            ],
 
             # --- Original record for audit / debugging ---
             "raw_data": (. | tostring)

--- a/ocsf/v1.3.0/tenable/tenable-vulnerabilities.yaml
+++ b/ocsf/v1.3.0/tenable/tenable-vulnerabilities.yaml
@@ -1,13 +1,12 @@
-name: "Tenable Vulnerability Findings to OCSF v1.1.0"
-description: "Transforms Tenable Vulnerability Findings into the OCSF v1.1.0 Vulnerability Finding class."
+name: "Tenable Vulnerability Findings to OCSF v1.3.0"
+description: "Transforms Tenable Vulnerability Findings into the OCSF v1.3.0 Vulnerability Finding class."
 author: "Monad"
 contributors:
-  - "https://github.com/Credgate"
   - "https://github.com/behobu"
 inputs:
   - "tenable-vulnerabilities"
 tags:
-  - "v1.1.0"
+  - "v1.3.0"
   - "ocsf"
   - "tenable"
   - "vulnerability"
@@ -19,7 +18,7 @@ config:
         key: ""
         query: |
           # ---------------------------------------------------------------
-          # OCSF Vulnerability Finding (class_uid=2002) — v1.1.0
+          # OCSF Vulnerability Finding (class_uid=2002) — v1.3.0
           # Input: one Tenable VM vulnerability export record per invocation.
           # ---------------------------------------------------------------
 
@@ -62,7 +61,7 @@ config:
             {"version": $ver, "base_score": $score}
             + (if $vec != null then {"vector_string": $vec} else {} end);
 
-          # Shared inputs reused across the vulnerabilities array.
+          # Shared inputs reused across the vulnerabilities array and observables.
           (.plugin // {}) as $p |
           (.asset // {}) as $a |
           ($p.see_also // []) as $refs |
@@ -121,7 +120,7 @@ config:
 
             # --- Metadata (REQUIRED) ---
             "metadata": {
-              "version": "1.1.0",
+              "version": "1.3.0",
               "product": {
                 "vendor_name": "Tenable",
                 "name": "Tenable Vulnerability Management"
@@ -145,7 +144,7 @@ config:
 
             # --- Vulnerabilities (REQUIRED) ---
             # The OCSF `vulnerability` object carries an `at_least_one:
-            # [cve, cwe]` constraint in v1.1.0. Emit one entry per CVE; if a
+            # [cve, cwe]` constraint in v1.3.0. Emit one entry per CVE; if a
             # plugin reports no CVE, fall back to CWE. (The `advisory` object
             # used as a last resort in v1.4.0+ does not exist in this version,
             # so a record with neither a CVE nor a CWE cannot satisfy the
@@ -160,13 +159,30 @@ config:
               end
             ),
 
-            # --- Recommended: generic resource ---
+            # --- Recommended: generic resource + plural resources ---
             "resource": {
               "type": "host",
               "name": ($a.hostname // $a.fqdn),
               "uid": $a.uuid,
               "labels": ($a.operating_system // [])
             },
+            "resources": [{
+              "type": "host",
+              "name": ($a.hostname // $a.fqdn),
+              "uid": $a.uuid,
+              "labels": ($a.operating_system // [])
+            }],
+
+            # --- Recommended: observables (natural pivots) ---
+            "observables": [
+              ( $cves[]? | { "name": "vulnerabilities.cve.uid", "type": "CVE Object: uid", "type_id": 18, "value": . } ),
+              (if ($a.hostname // $a.fqdn) != null
+                then { "name": "device.hostname", "type": "Hostname", "type_id": 1, "value": ($a.hostname // $a.fqdn) } else empty end),
+              (if $a.ipv4 != null
+                then { "name": "device.ip", "type": "IP Address", "type_id": 2, "value": $a.ipv4 } else empty end),
+              (if $a.mac_address != null
+                then { "name": "device.mac", "type": "MAC Address", "type_id": 3, "value": $a.mac_address } else empty end)
+            ],
 
             # --- Original record for audit / debugging ---
             "raw_data": (. | tostring)

--- a/ocsf/v1.4.0/tenable/tenable-vulnerabilities.yaml
+++ b/ocsf/v1.4.0/tenable/tenable-vulnerabilities.yaml
@@ -1,13 +1,12 @@
-name: "Tenable Vulnerability Findings to OCSF v1.1.0"
-description: "Transforms Tenable Vulnerability Findings into the OCSF v1.1.0 Vulnerability Finding class."
+name: "Tenable Vulnerability Findings to OCSF v1.4.0"
+description: "Transforms Tenable Vulnerability Findings into the OCSF v1.4.0 Vulnerability Finding class."
 author: "Monad"
 contributors:
-  - "https://github.com/Credgate"
   - "https://github.com/behobu"
 inputs:
   - "tenable-vulnerabilities"
 tags:
-  - "v1.1.0"
+  - "v1.4.0"
   - "ocsf"
   - "tenable"
   - "vulnerability"
@@ -19,7 +18,7 @@ config:
         key: ""
         query: |
           # ---------------------------------------------------------------
-          # OCSF Vulnerability Finding (class_uid=2002) — v1.1.0
+          # OCSF Vulnerability Finding (class_uid=2002) — v1.4.0
           # Input: one Tenable VM vulnerability export record per invocation.
           # ---------------------------------------------------------------
 
@@ -57,12 +56,25 @@ config:
           def status_caption($id):
             {"1":"New","2":"In Progress","4":"Resolved"}[$id|tostring] // "Other";
 
+          # OCSF os.type_id (+ caption): 100=Windows, 200=Linux, 300=macOS,
+          # 201=Android, 301=iOS, 99=Other.
+          def os_type_id:
+            (. // "" | ascii_downcase) as $o |
+            if   ($o | test("windows")) then 100
+            elif ($o | test("mac os|macos|os x")) then 300
+            elif ($o | test("android")) then 201
+            elif ($o | test("ios")) then 301
+            elif ($o | test("linux")) then 200
+            else 99 end;
+          def os_type_caption($id):
+            {"100":"Windows","200":"Linux","300":"macOS","201":"Android","301":"iOS"}[$id|tostring] // "Other";
+
           # Build one OCSF CVSS object, omitting the optional vector when absent.
           def mk_cvss($ver; $score; $vec):
             {"version": $ver, "base_score": $score}
             + (if $vec != null then {"vector_string": $vec} else {} end);
 
-          # Shared inputs reused across the vulnerabilities array.
+          # Shared inputs reused across vulnerabilities / device / observables.
           (.plugin // {}) as $p |
           (.asset // {}) as $a |
           ($p.see_also // []) as $refs |
@@ -121,7 +133,7 @@ config:
 
             # --- Metadata (REQUIRED) ---
             "metadata": {
-              "version": "1.1.0",
+              "version": "1.4.0",
               "product": {
                 "vendor_name": "Tenable",
                 "name": "Tenable Vulnerability Management"
@@ -144,29 +156,65 @@ config:
             },
 
             # --- Vulnerabilities (REQUIRED) ---
-            # The OCSF `vulnerability` object carries an `at_least_one:
-            # [cve, cwe]` constraint in v1.1.0. Emit one entry per CVE; if a
-            # plugin reports no CVE, fall back to CWE. (The `advisory` object
-            # used as a last resort in v1.4.0+ does not exist in this version,
-            # so a record with neither a CVE nor a CWE cannot satisfy the
-            # constraint — such records are rare in Tenable vulnerability data.)
+            # The OCSF `vulnerability` object carries a `just_one:
+            # [advisory, cve, cwe]` constraint (v1.4.0+). Emit one entry per
+            # CVE; if a plugin reports no CVE, fall back to CWE, then to an
+            # advisory synthesized from the plugin so the constraint holds.
             "vulnerabilities": (
               if ($cves | length) > 0 then
                 [ $cves[] as $id | $base_vuln + { "cve": ($cve_base + { "uid": $id }) } ]
               elif ($cwes | length) > 0 then
                 [ $cwes[] as $id | $base_vuln + { "cwe": { "uid": $id } } ]
               else
-                [ $base_vuln ]
+                [ $base_vuln + { "advisory": {
+                    "uid": ($p.id | tostring),
+                    "desc": ($p.synopsis // $p.description),
+                    "references": $refs
+                  } } ]
               end
             ),
 
-            # --- Recommended: generic resource ---
+            # --- Recommended: device (base-level attribute since v1.4.0) ---
+            "device": {
+              "type_id": 0,
+              "hostname": ($a.hostname // $a.fqdn),
+              "uid": $a.uuid,
+              "ip": $a.ipv4,
+              "mac": $a.mac_address,
+              "name": ($a.netbios_name // $a.fqdn // $a.hostname),
+              "os": (
+                ($a.operating_system // [] | first) as $os |
+                if $os != null then
+                  ($os | os_type_id) as $otid |
+                  { "name": $os, "type_id": $otid, "type": os_type_caption($otid) }
+                else null end
+              )
+            },
+
+            # --- Recommended: generic resource + plural resources ---
             "resource": {
               "type": "host",
               "name": ($a.hostname // $a.fqdn),
               "uid": $a.uuid,
               "labels": ($a.operating_system // [])
             },
+            "resources": [{
+              "type": "host",
+              "name": ($a.hostname // $a.fqdn),
+              "uid": $a.uuid,
+              "labels": ($a.operating_system // [])
+            }],
+
+            # --- Recommended: observables (natural pivots) ---
+            "observables": [
+              ( $cves[]? | { "name": "vulnerabilities.cve.uid", "type": "CVE Object: uid", "type_id": 18, "value": . } ),
+              (if ($a.hostname // $a.fqdn) != null
+                then { "name": "device.hostname", "type": "Hostname", "type_id": 1, "value": ($a.hostname // $a.fqdn) } else empty end),
+              (if $a.ipv4 != null
+                then { "name": "device.ip", "type": "IP Address", "type_id": 2, "value": $a.ipv4 } else empty end),
+              (if $a.mac_address != null
+                then { "name": "device.mac", "type": "MAC Address", "type_id": 3, "value": $a.mac_address } else empty end)
+            ],
 
             # --- Original record for audit / debugging ---
             "raw_data": (. | tostring)

--- a/ocsf/v1.5.0/tenable/tenable-vulnerabilities.yaml
+++ b/ocsf/v1.5.0/tenable/tenable-vulnerabilities.yaml
@@ -1,13 +1,12 @@
-name: "Tenable Vulnerability Findings to OCSF v1.1.0"
-description: "Transforms Tenable Vulnerability Findings into the OCSF v1.1.0 Vulnerability Finding class."
+name: "Tenable Vulnerability Findings to OCSF v1.5.0"
+description: "Transforms Tenable Vulnerability Findings into the OCSF v1.5.0 Vulnerability Finding class."
 author: "Monad"
 contributors:
-  - "https://github.com/Credgate"
   - "https://github.com/behobu"
 inputs:
   - "tenable-vulnerabilities"
 tags:
-  - "v1.1.0"
+  - "v1.5.0"
   - "ocsf"
   - "tenable"
   - "vulnerability"
@@ -19,7 +18,7 @@ config:
         key: ""
         query: |
           # ---------------------------------------------------------------
-          # OCSF Vulnerability Finding (class_uid=2002) — v1.1.0
+          # OCSF Vulnerability Finding (class_uid=2002) — v1.5.0
           # Input: one Tenable VM vulnerability export record per invocation.
           # ---------------------------------------------------------------
 
@@ -57,12 +56,25 @@ config:
           def status_caption($id):
             {"1":"New","2":"In Progress","4":"Resolved"}[$id|tostring] // "Other";
 
+          # OCSF os.type_id (+ caption): 100=Windows, 200=Linux, 300=macOS,
+          # 201=Android, 301=iOS, 99=Other.
+          def os_type_id:
+            (. // "" | ascii_downcase) as $o |
+            if   ($o | test("windows")) then 100
+            elif ($o | test("mac os|macos|os x")) then 300
+            elif ($o | test("android")) then 201
+            elif ($o | test("ios")) then 301
+            elif ($o | test("linux")) then 200
+            else 99 end;
+          def os_type_caption($id):
+            {"100":"Windows","200":"Linux","300":"macOS","201":"Android","301":"iOS"}[$id|tostring] // "Other";
+
           # Build one OCSF CVSS object, omitting the optional vector when absent.
           def mk_cvss($ver; $score; $vec):
             {"version": $ver, "base_score": $score}
             + (if $vec != null then {"vector_string": $vec} else {} end);
 
-          # Shared inputs reused across the vulnerabilities array.
+          # Shared inputs reused across vulnerabilities / device / observables.
           (.plugin // {}) as $p |
           (.asset // {}) as $a |
           ($p.see_also // []) as $refs |
@@ -121,7 +133,7 @@ config:
 
             # --- Metadata (REQUIRED) ---
             "metadata": {
-              "version": "1.1.0",
+              "version": "1.5.0",
               "product": {
                 "vendor_name": "Tenable",
                 "name": "Tenable Vulnerability Management"
@@ -144,29 +156,65 @@ config:
             },
 
             # --- Vulnerabilities (REQUIRED) ---
-            # The OCSF `vulnerability` object carries an `at_least_one:
-            # [cve, cwe]` constraint in v1.1.0. Emit one entry per CVE; if a
-            # plugin reports no CVE, fall back to CWE. (The `advisory` object
-            # used as a last resort in v1.4.0+ does not exist in this version,
-            # so a record with neither a CVE nor a CWE cannot satisfy the
-            # constraint — such records are rare in Tenable vulnerability data.)
+            # The OCSF `vulnerability` object carries a `just_one:
+            # [advisory, cve, cwe]` constraint (v1.5.0+). Emit one entry per
+            # CVE; if a plugin reports no CVE, fall back to CWE, then to an
+            # advisory synthesized from the plugin so the constraint holds.
             "vulnerabilities": (
               if ($cves | length) > 0 then
                 [ $cves[] as $id | $base_vuln + { "cve": ($cve_base + { "uid": $id }) } ]
               elif ($cwes | length) > 0 then
                 [ $cwes[] as $id | $base_vuln + { "cwe": { "uid": $id } } ]
               else
-                [ $base_vuln ]
+                [ $base_vuln + { "advisory": {
+                    "uid": ($p.id | tostring),
+                    "desc": ($p.synopsis // $p.description),
+                    "references": $refs
+                  } } ]
               end
             ),
 
-            # --- Recommended: generic resource ---
+            # --- Recommended: device (base-level attribute since v1.5.0) ---
+            "device": {
+              "type_id": 0,
+              "hostname": ($a.hostname // $a.fqdn),
+              "uid": $a.uuid,
+              "ip": $a.ipv4,
+              "mac": $a.mac_address,
+              "name": ($a.netbios_name // $a.fqdn // $a.hostname),
+              "os": (
+                ($a.operating_system // [] | first) as $os |
+                if $os != null then
+                  ($os | os_type_id) as $otid |
+                  { "name": $os, "type_id": $otid, "type": os_type_caption($otid) }
+                else null end
+              )
+            },
+
+            # --- Recommended: generic resource + plural resources ---
             "resource": {
               "type": "host",
               "name": ($a.hostname // $a.fqdn),
               "uid": $a.uuid,
               "labels": ($a.operating_system // [])
             },
+            "resources": [{
+              "type": "host",
+              "name": ($a.hostname // $a.fqdn),
+              "uid": $a.uuid,
+              "labels": ($a.operating_system // [])
+            }],
+
+            # --- Recommended: observables (natural pivots) ---
+            "observables": [
+              ( $cves[]? | { "name": "vulnerabilities.cve.uid", "type": "CVE Object: uid", "type_id": 18, "value": . } ),
+              (if ($a.hostname // $a.fqdn) != null
+                then { "name": "device.hostname", "type": "Hostname", "type_id": 1, "value": ($a.hostname // $a.fqdn) } else empty end),
+              (if $a.ipv4 != null
+                then { "name": "device.ip", "type": "IP Address", "type_id": 2, "value": $a.ipv4 } else empty end),
+              (if $a.mac_address != null
+                then { "name": "device.mac", "type": "MAC Address", "type_id": 3, "value": $a.mac_address } else empty end)
+            ],
 
             # --- Original record for audit / debugging ---
             "raw_data": (. | tostring)


### PR DESCRIPTION
## Summary

Builds the **`tenable-vulnerabilities`** input as OCSF **Vulnerability Finding** (`class_uid` 2002) across every published OCSF version that defines the class — **v1.1.0 → v1.5.0**.

`v1.0.0` is intentionally excluded: its Findings category only has Security Finding (2001), matching the `crowdstrike-vulnerabilities` precedent.

## Files (5)

| Version | Change | Ladder features |
|---|---|---|
| v1.1.0 | enriched (from the prior minimal Credgate mapping) | base: `finding_info`, `vulnerabilities`, `resource` |
| v1.2.0 | new | + `observables[]` |
| v1.3.0 | new | + `resources[]` (plural) |
| v1.4.0 | new | + `device{}` w/ nested `os{}`, `advisory` fallback |
| v1.5.0 | new | same shape as v1.4.0 |

Mirrors the progressive-enrichment ladder and conventions of `crowdstrike-vulnerabilities`. `author` is `"Monad"` on all five; the individual is a contributor.

## Mapping highlights

- **One `vulnerabilities[]` entry per CVE**, expanded from the deduped union of `plugin.cve` and `xrefs` CVE entries; each carries shared CVSS v3+v2, remediation, and references.
- **`severity_id`** is now derived from the Tenable severity label on the OCSF integer scale — fixing the prior v1.1.0 file, which passed Tenable's own string-typed scale straight through. Sibling strings (`severity`, `status`, `os.type`) are set to OCSF enum captions; raw Tenable `state` is preserved in `status_detail` and `raw_data`.
- The vulnerability **`just_one`/`at_least_one` constraint** is satisfied via `cve` → `cwe` → (v1.4.0+) a synthesized `advisory`.

## Validation

Validated with the version-pinned structural check and the official OCSF validator API. All CVE-bearing records pass with **zero errors on every version**. (A synthetic no-CVE record fails only on v1.1.0–v1.3.0, an inherent limitation of those schema versions, which lack the `advisory` fallback object.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)