### PR TITLE
feat(aws): add CloudTrail to ECS v8.0.0 transforms (core + comprehensive)

### DIFF
--- a/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
@@ -112,6 +112,10 @@ config:
               // sid($r.requestParameters)
               // sid($r.responseElements) ) as $source_identity
 
+          # The role name of an assumed-role session, i.e. the identity whose
+          # privileges are actually in effect. Null for non-session callers.
+          | ( real_name($sc.sessionIssuer.userName) ) as $issuer_name
+
           | {
               ecs: { version: "8.0.0" },
 
@@ -136,13 +140,34 @@ config:
                 account: { id: ($r.recipientAccountId // $ui.accountId) }
               },
 
-              user: {
-                # IdentityCenterUser events (and Identity Center events typed
-                # "Unknown") carry no principalId; the Identity Store user id
-                # in onBehalfOf is the only stable identifier available.
-                id: ($ui.principalId // $ui.onBehalfOf.userId),
-                name: $user_name
-              },
+              # ECS models user.* as the identity that INITIATED the action and
+              # user.effective.* as the identity whose privileges were used -
+              # the `sudo` model. When STS is configured to require a
+              # sourceIdentity, an assumed-role call gives us both: the human
+              # initiated it, the role's privileges carried it out.
+              #
+              # NOTE this makes user.name intentionally bimodal - the human
+              # where sourceIdentity is configured, otherwise the role or IAM
+              # user name, which is the only identity CloudTrail supplies.
+              # user.effective.* is populated ONLY when it differs from
+              # user.*, so it never merely duplicates it.
+              user: (
+                if $source_identity != null and $issuer_name != null then {
+                  name: $source_identity,
+                  # CloudTrail carries no id for the source identity itself;
+                  # the role session principal becomes the effective id.
+                  effective: {
+                    id: $ui.principalId,
+                    name: $issuer_name
+                  }
+                } else {
+                  # IdentityCenterUser events (and Identity Center events typed
+                  # "Unknown") carry no principalId; the Identity Store user id
+                  # in onBehalfOf is the only stable identifier available.
+                  id: ($ui.principalId // $ui.onBehalfOf.userId),
+                  name: ($source_identity // $user_name)
+                } end
+              ),
 
               source: {
                 address: $r.sourceIPAddress,

--- a/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
@@ -23,8 +23,11 @@ config:
           #
           # Input: ONE CloudTrail event record per invocation, as emitted by
           #   the Monad `cloudtrail` input connector. (For the S3/SQS
-          #   connector `aws-sqs-s3-cloudtrail`, explode `.Records[]` in an
-          #   upstream transform first — it emits chunked Records arrays.)
+          #   connector `aws-sqs-s3-cloudtrail` this depends on its Chunking
+          #   Mode: `per_record` already emits one bare event per record and
+          #   needs nothing extra, while `by_size` — the default — emits the
+          #   CloudTrail envelope with `Records` chunked, so explode
+          #   `.Records[]` in an upstream transform first.)
           #
           # Superset of the Core transform. In addition to the core ECS
           # fields (event, cloud, user, source, user_agent, related) it maps
@@ -54,24 +57,24 @@ config:
           . as $r
 
           | ( if ($r.errorCode // null) != null then "failure"
-              elif $r.eventName == "ConsoleLogin"
+              elif ($r.eventName // "") == "ConsoleLogin"
                 then ( if ($r.responseElements.ConsoleLogin // "") == "Success"
                        then "success" else "failure" end )
               else "success" end ) as $outcome
 
-          | ( if ($r.eventName | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
+          | ( if (($r.eventName // "") | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
                 then ["authentication"]
               elif ($r.eventSource // "") | test("^(iam|sso|signin)\\.")
                 then ["iam"]
               else ["configuration"] end ) as $category
 
-          | ( if $r.eventName == "ConsoleLogin" then ["start"]
+          | ( if ($r.eventName // "") == "ConsoleLogin" then ["start"]
               elif ($r.readOnly // false) == true then ["access"]
-              elif ($r.eventName | test("^(Create|Add|Enable|Register|Put|Allocate|Import|Run|Provision|Attach|Associate)"))
+              elif (($r.eventName // "") | test("^(Create|Add|Enable|Register|Put|Allocate|Import|Run|Provision|Attach|Associate)"))
                 then ["creation"]
-              elif ($r.eventName | test("^(Delete|Remove|Deregister|Disable|Detach|Disassociate|Terminate|Revoke)"))
+              elif (($r.eventName // "") | test("^(Delete|Remove|Deregister|Disable|Detach|Disassociate|Terminate|Revoke)"))
                 then ["deletion"]
-              elif ($r.eventName | test("^(Update|Modify|Set|Change|Replace)"))
+              elif (($r.eventName // "") | test("^(Update|Modify|Set|Change|Replace)"))
                 then ["change"]
               else ["info"] end ) as $type
 

--- a/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
@@ -1,5 +1,5 @@
 name: "AWS CloudTrail to ECS v8.0.0 (Comprehensive)"
-description: "Normalizes individual AWS CloudTrail event records into the Elastic Common Schema (ECS) v8.0.0 with full field coverage: core ECS fields plus the aws.cloudtrail.* namespace, error.*, tls.*, session context, resources, and event.original."
+description: "Normalizes individual AWS CloudTrail event records into the Elastic Common Schema (ECS) v8.0.0 with full field coverage: core ECS fields plus the aws.cloudtrail.* namespace, error.*, tls.*, federation and issued-credential detail, session context, resources, and event.original. Resolves the acting identity across every AWS sign-in form (IAM user, SAML/OIDC federation, IAM Identity Center users, and Identity Center role assumption)."
 author: "Monad"
 contributors:
   - "https://github.com/behobu"
@@ -39,6 +39,29 @@ config:
           #   - event.original                      <- the whole raw record
           # Field names under aws.cloudtrail.* follow the Elastic AWS
           # integration's snake_case convention.
+          #
+          # ---- ELASTICSEARCH MAPPING NOTES --------------------------------
+          # requestParameters, responseElements and additionalEventData are
+          # emitted as JSON *strings*, not objects. This is deliberate and
+          # matches the type Elastic's own AWS CloudTrail integration uses
+          # (`aws.cloudtrail.request_parameters` is a `keyword`). Emitting
+          # them as objects breaks Elasticsearch two ways:
+          #   1. Mapping explosion - every parameter name of every AWS API
+          #      becomes a distinct field, blowing the index field limit.
+          #   2. Type conflicts that REJECT documents - the same key is not
+          #      consistently typed across APIs. Real example from a live org
+          #      trail: apigateway sends {"maxResults": "100"} (string) while
+          #      ec2 sends {"maxResults": 100} (number). Whichever indexes
+          #      first wins the mapping and the other is dropped.
+          # The security-relevant contents are ALSO extracted into typed,
+          # queryable fields (sign_in, federation, issued_credentials) so no
+          # investigation has to parse the string. If you want the blobs
+          # queryable too, map `aws.cloudtrail.flattened.*` as `flattened` in
+          # your index template and change json_str() to pass the object.
+          #
+          # Sub-keys cannot be pruned from these fields downstream once they
+          # are strings, so any field-level trimming (e.g. dropping a session
+          # token) must happen in an UPSTREAM transform on the raw record.
           # =================================================================
 
           def is_ip($s):
@@ -53,12 +76,25 @@ config:
             if ($s | type) == "string" and $s != "HIDDEN_DUE_TO_SECURITY_REASONS"
             then $s else null end;
 
-          # sourceIdentity is the original identity behind an assumed role. Only
-          # present when STS is configured to require it. requestParameters
-          # and responseElements are not always objects, hence the type guard.
-          def sid($o):
-            if ($o | type) == "object" then real_name($o.sourceIdentity)
-            else null end;
+          # requestParameters / responseElements / additionalEventData are not
+          # always JSON objects (a bare string aborts the whole transform when
+          # indexed), so every read of them goes through this guard.
+          def g($o; $k): if ($o | type) == "object" then $o[$k] else null end;
+
+          def sid($o): real_name(g($o; "sourceIdentity"));
+
+          # See the ELASTICSEARCH MAPPING NOTES above. null and {} collapse to
+          # null so prune drops them rather than storing the string "null".
+          def json_str($v):
+            if $v == null then null
+            elif ($v | type) == "object" and ($v | length) == 0 then null
+            else ($v | tostring) end;
+
+          # The session-name half of an assumed-role principalId
+          # ("AROAEXAMPLE:session-name" -> "session-name").
+          def session_name($p):
+            if ($p | type) == "string" and ($p | test(":"))
+            then ($p | sub("^[^:]*:"; "")) else null end;
 
           def prune:
             walk(
@@ -70,26 +106,48 @@ config:
             );
 
           . as $r
+          | ( $r.userIdentity // {} ) as $ui
+          | ( $ui.sessionContext // {} ) as $sc
+          | ( $r.requestParameters ) as $rp
+          | ( $r.responseElements ) as $re
+          | ( $r.additionalEventData ) as $aed
 
+          # ---- outcome ----------------------------------------------------
+          # additionalEventData.success covers the signin.amazonaws.com OAuth2
+          # events, which report failure there rather than via errorCode.
           | ( if ($r.errorCode // null) != null then "failure"
               elif ($r.eventName // "") == "ConsoleLogin"
-                then ( if ($r.responseElements.ConsoleLogin // "") == "Success"
+                then ( if (g($re; "ConsoleLogin") // "") == "Success"
                        then "success" else "failure" end )
+              elif (g($aed; "success") // "") == "false" then "failure"
               else "success" end ) as $outcome
 
-          | ( if (($r.eventName // "") | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
+          # ---- event.category --------------------------------------------
+          # Every AWS sign-in form must land in `authentication`, because that
+          # is what SIEM detection content keys on:
+          #   - IAM user / root console password sign-in .. ConsoleLogin
+          #   - SAML or OIDC federated role assumption ... AssumeRoleWith*
+          #   - plain / chained role assumption .......... AssumeRole, AssumeRoot
+          #   - IAM Identity Center sign-in and tokens ... sso*/signin* events
+          | ( if (($r.eventName // "") | test("^(ConsoleLogin|SwitchRole|ExitRole|RenewRole|CheckMfa|AssumeRole|AssumeRoot|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
                 then ["authentication"]
               # IAM Identity Center sign-in and token/credential issuance.
               # This MUST be tested before the eventSource "iam" rule below,
               # which would otherwise swallow every sso./signin. event.
               elif (($r.eventSource // "") | test("^(sso|sso-oidc|signin|identitystore)\\."))
-                   and (($r.eventName // "") | test("^(Authenticate|UserAuthentication|CredentialChallenge|CredentialVerification|Federate|CreateToken|CreateTokenWithIAM|StartDeviceAuthorization|Authorize|GetRoleCredentials|SSOSignIn)$"))
+                   and (($r.eventName // "") | test("^(Authenticate|UserAuthentication|CredentialChallenge|CredentialVerification|Federate|CreateToken|CreateTokenWithIAM|StartDeviceAuthorization|Authorize|AuthorizeOAuth2Access|CreateOAuth2Token|GetRoleCredentials|SSOSignIn)$"))
                 then ["authentication"]
               elif ($r.eventSource // "") | test("^(iam|sso|signin)\\.")
                 then ["iam"]
               else ["configuration"] end ) as $category
 
-          | ( if ($r.eventName // "") == "ConsoleLogin" then ["start"]
+          # ---- event.type (ECS allowed values) ---------------------------
+          # An authentication event is a session beginning, so it takes
+          # `start` rather than `access`. ECS pairs category=authentication
+          # with type=start/end/info, and detection content expects `start`.
+          # ExitRole ends a session instead.
+          | ( if ($r.eventName // "") == "ExitRole" then ["end"]
+              elif $category == ["authentication"] then ["start"]
               elif ($r.readOnly // false) == true then ["access"]
               elif (($r.eventName // "") | test("^(Create|Add|Enable|Register|Put|Allocate|Import|Run|Provision|Attach|Associate)"))
                 then ["creation"]
@@ -99,22 +157,36 @@ config:
                 then ["change"]
               else ["info"] end ) as $type
 
-          | ( real_name($r.userIdentity.userName)
-              // real_name($r.userIdentity.sessionContext.sessionIssuer.userName)
-              # IAM Identity Center no longer emits userIdentity.userName or
-              # principalId. The username is emitted once per successful
-              # sign-in under additionalEventData.UserName instead.
-              // real_name($r.additionalEventData.UserName) ) as $user_name
-
-          | ( $r.userIdentity // {} ) as $ui
-          | ( $ui.sessionContext // {} ) as $sc
-          | ( sid($sc)
-              // sid($r.requestParameters)
-              // sid($r.responseElements) ) as $source_identity
-
-          # The role name of an assumed-role session, i.e. the identity whose
-          # privileges are actually in effect. Null for non-session callers.
-          | ( real_name($sc.sessionIssuer.userName) ) as $issuer_name
+          # ---- IDENTITY RESOLUTION ---------------------------------------
+          # CloudTrail puts the acting identity in a different place for each
+          # sign-in form, and for a plain assumed-role session it supplies no
+          # human at all. Resolved most-authoritative first:
+          #
+          #  1. sourceIdentity ....... the originating human, when STS is
+          #       configured to require it. Survives role chaining.
+          #  2. Identity Center role assumption (what a mature setup does:
+          #       IdP -> Identity Center -> permission set). userIdentity.type
+          #       is "AssumedRole" and onBehalfOf sits ALONGSIDE principalId,
+          #       whose session-name half is the Identity Center username.
+          #  3. additionalEventData.UserName .. Identity Center sign-in events
+          #       (CredentialChallenge / UserAuthentication). AWS documents
+          #       this as the only username source for Identity Center.
+          #  4. userIdentity.userName ... IAMUser (console password sign-in),
+          #       SAMLUser (the saml:sub), WebIdentityUser (the OIDC user id),
+          #       Root (the account alias).
+          #  5. sessionIssuer.userName .. last resort: the ROLE name, not a
+          #       person. Only used when nothing above identifies a human.
+          | ( g($ui.onBehalfOf; "userId") ) as $idc_user_id
+          | ( if $idc_user_id != null then session_name($ui.principalId)
+              else null end ) as $idc_name
+          | ( sid($sc) // sid($rp) // sid($re) ) as $source_identity
+          | ( $source_identity
+              // $idc_name
+              // real_name(g($aed; "UserName"))
+              // real_name($ui.userName) ) as $actor
+          # The role whose privileges are in effect. Null for non-session
+          # callers (IAM user, SAML/OIDC assume calls, Identity Center users).
+          | ( real_name($sc.sessionIssuer.userName) ) as $role_name
 
           | {
               ecs: { version: "8.0.0" },
@@ -142,30 +214,28 @@ config:
 
               # ECS models user.* as the identity that INITIATED the action and
               # user.effective.* as the identity whose privileges were used -
-              # the `sudo` model. When STS is configured to require a
-              # sourceIdentity, an assumed-role call gives us both: the human
-              # initiated it, the role's privileges carried it out.
+              # the `sudo` model. Where CloudTrail gives us both a human and
+              # the role they acted through, that maps exactly.
               #
-              # NOTE this makes user.name intentionally bimodal - the human
-              # where sourceIdentity is configured, otherwise the role or IAM
-              # user name, which is the only identity CloudTrail supplies.
-              # user.effective.* is populated ONLY when it differs from
-              # user.*, so it never merely duplicates it.
+              # NOTE user.name is intentionally bimodal: the human wherever one
+              # is identifiable (see IDENTITY RESOLUTION above), otherwise the
+              # role name, which is the only identity CloudTrail supplies for a
+              # plain assumed-role session. user.effective.* is populated ONLY
+              # when it differs from user.*, so it never merely duplicates it.
               user: (
-                if $source_identity != null and $issuer_name != null then {
-                  name: $source_identity,
-                  # CloudTrail carries no id for the source identity itself;
-                  # the role session principal becomes the effective id.
+                if $actor != null and $role_name != null then {
+                  # Identity Center supplies a stable, immutable user id; other
+                  # forms carry no id for the human, so user.id is omitted
+                  # rather than filled with the role session principal.
+                  id: $idc_user_id,
+                  name: $actor,
                   effective: {
                     id: $ui.principalId,
-                    name: $issuer_name
+                    name: $role_name
                   }
                 } else {
-                  # IdentityCenterUser events (and Identity Center events typed
-                  # "Unknown") carry no principalId; the Identity Store user id
-                  # in onBehalfOf is the only stable identifier available.
-                  id: ($ui.principalId // $ui.onBehalfOf.userId),
-                  name: ($source_identity // $user_name)
+                  id: ($idc_user_id // $ui.principalId),
+                  name: ($actor // $role_name)
                 } end
               ),
 
@@ -191,10 +261,16 @@ config:
 
               related: {
                 ip: ( if is_ip($r.sourceIPAddress) then [$r.sourceIPAddress] else [] end ),
-                user: ( [ $user_name,
+                # Every identifier for the actor seen anywhere on the event, so
+                # a single related.user search finds the activity whichever
+                # sign-in form produced it.
+                user: ( [ $actor,
+                          $role_name,
                           $source_identity,
+                          $idc_name,
                           real_name($ui.userName),
-                          real_name($sc.sessionIssuer.userName) ]
+                          real_name(g($aed; "UserName")),
+                          real_name(g($re; "subject")) ]
                         | map(select(. != null)) | unique )
               },
 
@@ -214,11 +290,66 @@ config:
                   error_code: $r.errorCode,
                   error_message: $r.errorMessage,
 
-                  # Parameters kept as structured objects (flattened type).
-                  request_parameters: $r.requestParameters,
-                  response_elements: $r.responseElements,
-                  additional_eventdata: $r.additionalEventData,
-                  service_event_details: $r.serviceEventDetails,
+                  # JSON strings, not objects — see ELASTICSEARCH MAPPING
+                  # NOTES at the top of this transform.
+                  request_parameters: json_str($rp),
+                  response_elements: json_str($re),
+                  additional_eventdata: json_str($aed),
+                  service_event_details: json_str($r.serviceEventDetails),
+
+                  # ---- Credentials issued by an AssumeRole* / GetSessionToken
+                  # THE pivot key for incident response. AWS documents that a
+                  # role's subsequent API calls carry "role identity only (no
+                  # user)", so access_key_id is what joins this sign-in event
+                  # to everything the resulting session went on to do:
+                  #   aws.cloudtrail.issued_credentials.access_key_id
+                  #     -> aws.cloudtrail.user_identity.access_key_id
+                  # An access key id is an identifier, not a secret (the secret
+                  # is the session token, which must be dropped upstream).
+                  issued_credentials: {
+                    access_key_id: g(g($re; "credentials"); "accessKeyId"),
+                    expiration: g(g($re; "credentials"); "expiration"),
+                    assumed_role_arn: g(g($re; "assumedRoleUser"); "arn"),
+                    assumed_role_id: g(g($re; "assumedRoleUser"); "assumedRoleId")
+                  },
+
+                  # ---- Federated sign-in detail (SAML and OIDC)
+                  # Identifies WHICH identity provider asserted the login -
+                  # the question that matters first when a federated account
+                  # is suspected of compromise.
+                  federation: {
+                    # SAMLUser: the saml:namequalifier. WebIdentityUser: the
+                    # OIDC provider ARN.
+                    identity_provider: $ui.identityProvider,
+                    # AssumeRoleWithSAML responseElements: the IdP issuer URL.
+                    issuer: g($re; "issuer"),
+                    subject: g($re; "subject"),
+                    subject_type: g($re; "subjectType"),
+                    audience: g($re; "audience"),
+                    name_qualifier: g($re; "nameQualifier"),
+                    saml_assertion_id: g($rp; "sAMLAssertionID"),
+                    # The IAM saml-provider / oidc-provider being trusted.
+                    principal_arn: g($rp; "principalArn"),
+                    # AssumeRoleWithWebIdentity: the OIDC subject.
+                    web_identity_subject: g($re; "subjectFromWebIdentityToken"),
+                    web_id_federated_provider: $sc.webIdFederationData.federatedProvider
+                  },
+
+                  # ---- Sign-in detail across all forms
+                  # Extracted from additionalEventData so these stay queryable
+                  # even though the blob itself is a string.
+                  sign_in: {
+                    # Console password sign-in (IAM user / root).
+                    mfa_used: g($aed; "MFAUsed"),
+                    mobile_version: g($aed; "MobileVersion"),
+                    login_to: g($aed; "LoginTo"),
+                    # IAM Identity Center sign-in sequence.
+                    auth_workflow_id: g($aed; "AuthWorkflowID"),
+                    credential_type: g($aed; "CredentialType"),
+                    user_name: g($aed; "UserName"),
+                    device_enrollment_required: g($aed; "DeviceEnrollmentRequired"),
+                    success: g($aed; "success")
+                  },
 
                   user_identity: {
                     type: $ui.type,
@@ -227,45 +358,68 @@ config:
                     account_id: $ui.accountId,
                     access_key_id: $ui.accessKeyId,
                     user_name: $ui.userName,
+                    # The AWS service that made the call. NOT a duplicate of
+                    # event.provider (the service being called) - this is the
+                    # service/human distinction.
                     invoked_by: $ui.invokedBy,
+                    # SAMLUser / WebIdentityUser identity provider.
+                    identity_provider: $ui.identityProvider,
 
                     # Set when the caller uses a bearer token, such as an IAM
                     # Identity Center authorized access token. Correlates the
                     # AWS access portal actions taken in one signed-in session.
                     credential_id: $ui.credentialId,
 
-                    # Present when the caller is an IAM Identity Center user
-                    # (userIdentity.type "IdentityCenterUser"); identifies the
-                    # Identity Center user the call was made on behalf of.
+                    # Present for IAM Identity Center callers - both
+                    # userIdentity.type "IdentityCenterUser" and, for Identity
+                    # Center role assumption, "AssumedRole" alongside
+                    # principalId. userId is the immutable Identity Store id
+                    # AWS recommends for identifying the person.
                     on_behalf_of: {
-                      user_id: $ui.onBehalfOf.userId,
-                      identity_store_arn: $ui.onBehalfOf.identityStoreArn
+                      user_id: $idc_user_id,
+                      identity_store_arn: g($ui.onBehalfOf; "identityStoreArn")
                     },
+
+                    # Which resource was issued these credentials (e.g. the
+                    # EC2 instance or Lambda function) - ties a session to the
+                    # compute that holds it.
+                    in_scope_of: {
+                      source_arn: g($ui.inScopeOf; "sourceArn"),
+                      source_account: g($ui.inScopeOf; "sourceAccount"),
+                      issuer_type: g($ui.inScopeOf; "issuerType"),
+                      credentials_issued_to: g($ui.inScopeOf; "credentialsIssuedTo")
+                    },
+
+                    # A product provider acting under delegated access.
+                    invoked_by_delegate_account_id: g($ui.invokedByDelegate; "accountId"),
 
                     session_context: {
                       mfa_authenticated: $sc.attributes.mfaAuthenticated,
                       creation_date: $sc.attributes.creationDate,
                       source_identity: $sc.sourceIdentity,
-                      session_issuer: {
-                        type: $sc.sessionIssuer.type,
-                        principal_id: $sc.sessionIssuer.principalId,
-                        arn: $sc.sessionIssuer.arn,
-                        account_id: $sc.sessionIssuer.accountId,
-                        user_name: $sc.sessionIssuer.userName
-                      }
+                      # IMDSv1 ("1.0") vs IMDSv2 ("2.0") credential delivery.
+                      ec2_role_delivery: $sc.ec2RoleDelivery,
+                      # True for a management-account AssumeRoot session.
+                      assumed_root: $sc.assumedRoot,
+                      # Identifies the sign-in session more precisely than the
+                      # principal ARN; use it to audit or revoke by session.
+                      sign_in_session_arn: $sc.signInSessionArn
+                    },
+
+                    # Sibling of session_context, matching the field layout of
+                    # Elastic's AWS CloudTrail integration
+                    # (aws.cloudtrail.user_identity.session_issuer.*).
+                    session_issuer: {
+                      type: $sc.sessionIssuer.type,
+                      principal_id: $sc.sessionIssuer.principalId,
+                      arn: $sc.sessionIssuer.arn,
+                      account_id: $sc.sessionIssuer.accountId,
+                      user_name: $sc.sessionIssuer.userName
                     }
                   },
 
                   resources: ( ($r.resources // [])
-                    | map({ arn: .ARN, account_id: .accountId, type: .type }) ),
-
-                  console_login: (
-                    if ($r.additionalEventData // null) != null then {
-                      mfa_used: $r.additionalEventData.MFAUsed,
-                      mobile_version: $r.additionalEventData.MobileVersion,
-                      login_to: $r.additionalEventData.LoginTo
-                    } else null end
-                  )
+                    | map({ arn: .ARN, account_id: .accountId, type: .type }) )
                 }
               }
             }

--- a/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
@@ -1,0 +1,195 @@
+name: "AWS CloudTrail to ECS v8.0.0 (Comprehensive)"
+description: "Normalizes individual AWS CloudTrail event records into the Elastic Common Schema (ECS) v8.0.0 with full field coverage: core ECS fields plus the aws.cloudtrail.* namespace, error.*, tls.*, session context, resources, and event.original."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudtrail"
+tags:
+  - "v8.0.0"
+  - "ecs"
+  - "aws"
+  - "cloudtrail"
+  - "audit"
+  - "comprehensive"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # AWS CloudTrail  ->  ECS v8.0.0  (COMPREHENSIVE)
+          #
+          # Input: ONE CloudTrail event record per invocation, as emitted by
+          #   the Monad `cloudtrail` input connector. (For the S3/SQS
+          #   connector `aws-sqs-s3-cloudtrail`, explode `.Records[]` in an
+          #   upstream transform first — it emits chunked Records arrays.)
+          #
+          # Superset of the Core transform. In addition to the core ECS
+          # fields (event, cloud, user, source, user_agent, related) it maps
+          # every CloudTrail field with an ECS or aws.cloudtrail.* home:
+          #   - error.code / error.message          <- errorCode / errorMessage
+          #   - tls.version / tls.cipher / tls.client.server_name
+          #   - aws.cloudtrail.* (user_identity, session_context, resources,
+          #     request/response parameters, read_only, management_event, ...)
+          #   - event.original                      <- the whole raw record
+          # Field names under aws.cloudtrail.* follow the Elastic AWS
+          # integration's snake_case convention.
+          # =================================================================
+
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+
+          | ( if ($r.errorCode // null) != null then "failure"
+              elif $r.eventName == "ConsoleLogin"
+                then ( if ($r.responseElements.ConsoleLogin // "") == "Success"
+                       then "success" else "failure" end )
+              else "success" end ) as $outcome
+
+          | ( if ($r.eventName | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
+                then ["authentication"]
+              elif ($r.eventSource // "") | test("^(iam|sso|signin)\\.")
+                then ["iam"]
+              else ["configuration"] end ) as $category
+
+          | ( if $r.eventName == "ConsoleLogin" then ["start"]
+              elif ($r.readOnly // false) == true then ["access"]
+              elif ($r.eventName | test("^(Create|Add|Enable|Register|Put|Allocate|Import|Run|Provision|Attach|Associate)"))
+                then ["creation"]
+              elif ($r.eventName | test("^(Delete|Remove|Deregister|Disable|Detach|Disassociate|Terminate|Revoke)"))
+                then ["deletion"]
+              elif ($r.eventName | test("^(Update|Modify|Set|Change|Replace)"))
+                then ["change"]
+              else ["info"] end ) as $type
+
+          | ( $r.userIdentity.userName
+              // $r.userIdentity.sessionContext.sessionIssuer.userName ) as $user_name
+
+          | ( $r.userIdentity // {} ) as $ui
+          | ( $ui.sessionContext // {} ) as $sc
+
+          | {
+              ecs: { version: "8.0.0" },
+
+              "@timestamp": $r.eventTime,
+
+              event: {
+                kind: "event",
+                module: "aws",
+                dataset: "aws.cloudtrail",
+                provider: $r.eventSource,
+                action: $r.eventName,
+                id: $r.eventID,
+                category: $category,
+                type: $type,
+                outcome: $outcome,
+                original: ($r | tostring)
+              },
+
+              cloud: {
+                provider: "aws",
+                region: $r.awsRegion,
+                account: { id: ($r.recipientAccountId // $ui.accountId) }
+              },
+
+              user: {
+                id: $ui.principalId,
+                name: $user_name
+              },
+
+              source: {
+                address: $r.sourceIPAddress,
+                ip: ( if is_ip($r.sourceIPAddress) then $r.sourceIPAddress else null end )
+              },
+
+              user_agent: { original: $r.userAgent },
+
+              # error.* — only populated on failed calls.
+              error: {
+                code: $r.errorCode,
+                message: $r.errorMessage
+              },
+
+              # tls.* — from CloudTrail tlsDetails when present.
+              tls: {
+                version: $r.tlsDetails.tlsVersion,
+                cipher: $r.tlsDetails.cipherSuite,
+                client: { server_name: $r.tlsDetails.clientProvidedHostHeader }
+              },
+
+              related: {
+                ip: ( if is_ip($r.sourceIPAddress) then [$r.sourceIPAddress] else [] end ),
+                user: ( [ $user_name, $ui.userName, $sc.sessionIssuer.userName ]
+                        | map(select(. != null)) | unique )
+              },
+
+              # ---- Vendor namespace: full CloudTrail fidelity ------------
+              aws: {
+                cloudtrail: {
+                  event_version: $r.eventVersion,
+                  event_type: $r.eventType,
+                  event_category: $r.eventCategory,
+                  api_version: $r.apiVersion,
+                  management_event: $r.managementEvent,
+                  read_only: $r.readOnly,
+                  request_id: $r.requestID,
+                  recipient_account_id: $r.recipientAccountId,
+                  shared_event_id: $r.sharedEventID,
+                  vpc_endpoint_id: $r.vpcEndpointId,
+                  error_code: $r.errorCode,
+                  error_message: $r.errorMessage,
+
+                  # Parameters kept as structured objects (flattened type).
+                  request_parameters: $r.requestParameters,
+                  response_elements: $r.responseElements,
+                  additional_eventdata: $r.additionalEventData,
+                  service_event_details: $r.serviceEventDetails,
+
+                  user_identity: {
+                    type: $ui.type,
+                    principal_id: $ui.principalId,
+                    arn: $ui.arn,
+                    account_id: $ui.accountId,
+                    access_key_id: $ui.accessKeyId,
+                    user_name: $ui.userName,
+                    invoked_by: $ui.invokedBy,
+                    session_context: {
+                      mfa_authenticated: $sc.attributes.mfaAuthenticated,
+                      creation_date: $sc.attributes.creationDate,
+                      session_issuer: {
+                        type: $sc.sessionIssuer.type,
+                        principal_id: $sc.sessionIssuer.principalId,
+                        arn: $sc.sessionIssuer.arn,
+                        account_id: $sc.sessionIssuer.accountId,
+                        user_name: $sc.sessionIssuer.userName
+                      }
+                    }
+                  },
+
+                  resources: ( ($r.resources // [])
+                    | map({ arn: .ARN, account_id: .accountId, type: .type }) ),
+
+                  console_login: (
+                    if ($r.additionalEventData // null) != null then {
+                      mfa_used: $r.additionalEventData.MFAUsed,
+                      mobile_version: $r.additionalEventData.MobileVersion,
+                      login_to: $r.additionalEventData.LoginTo
+                    } else null end
+                  )
+                }
+              }
+            }
+          | prune

--- a/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
@@ -45,6 +45,14 @@ config:
             ($s | type) == "string"
             and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
 
+          # CloudTrail replaces a user name with this sentinel when a console
+          # sign-in fails because of bad username input, and IAM Identity
+          # Center does the same for additionalEventData.UserName. It is a
+          # redaction marker, not an identity - never surface it as user.name.
+          def real_name($s):
+            if ($s | type) == "string" and $s != "HIDDEN_DUE_TO_SECURITY_REASONS"
+            then $s else null end;
+
           def prune:
             walk(
               if type == "object" then
@@ -64,6 +72,12 @@ config:
 
           | ( if (($r.eventName // "") | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
                 then ["authentication"]
+              # IAM Identity Center sign-in and token/credential issuance.
+              # This MUST be tested before the eventSource "iam" rule below,
+              # which would otherwise swallow every sso./signin. event.
+              elif (($r.eventSource // "") | test("^(sso|sso-oidc|signin|identitystore)\\."))
+                   and (($r.eventName // "") | test("^(Authenticate|UserAuthentication|CredentialChallenge|CredentialVerification|Federate|CreateToken|CreateTokenWithIAM|StartDeviceAuthorization|Authorize|GetRoleCredentials|SSOSignIn)$"))
+                then ["authentication"]
               elif ($r.eventSource // "") | test("^(iam|sso|signin)\\.")
                 then ["iam"]
               else ["configuration"] end ) as $category
@@ -78,8 +92,12 @@ config:
                 then ["change"]
               else ["info"] end ) as $type
 
-          | ( $r.userIdentity.userName
-              // $r.userIdentity.sessionContext.sessionIssuer.userName ) as $user_name
+          | ( real_name($r.userIdentity.userName)
+              // real_name($r.userIdentity.sessionContext.sessionIssuer.userName)
+              # IAM Identity Center no longer emits userIdentity.userName or
+              # principalId. The username is emitted once per successful
+              # sign-in under additionalEventData.UserName instead.
+              // real_name($r.additionalEventData.UserName) ) as $user_name
 
           | ( $r.userIdentity // {} ) as $ui
           | ( $ui.sessionContext // {} ) as $sc
@@ -109,7 +127,10 @@ config:
               },
 
               user: {
-                id: $ui.principalId,
+                # IdentityCenterUser events (and Identity Center events typed
+                # "Unknown") carry no principalId; the Identity Store user id
+                # in onBehalfOf is the only stable identifier available.
+                id: ($ui.principalId // $ui.onBehalfOf.userId),
                 name: $user_name
               },
 
@@ -135,7 +156,9 @@ config:
 
               related: {
                 ip: ( if is_ip($r.sourceIPAddress) then [$r.sourceIPAddress] else [] end ),
-                user: ( [ $user_name, $ui.userName, $sc.sessionIssuer.userName ]
+                user: ( [ $user_name,
+                          real_name($ui.userName),
+                          real_name($sc.sessionIssuer.userName) ]
                         | map(select(. != null)) | unique )
               },
 
@@ -169,6 +192,11 @@ config:
                     access_key_id: $ui.accessKeyId,
                     user_name: $ui.userName,
                     invoked_by: $ui.invokedBy,
+
+                    # Set when the caller uses a bearer token, such as an IAM
+                    # Identity Center authorized access token. Correlates the
+                    # AWS access portal actions taken in one signed-in session.
+                    credential_id: $ui.credentialId,
 
                     # Present when the caller is an IAM Identity Center user
                     # (userIdentity.type "IdentityCenterUser"); identifies the

--- a/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
@@ -169,6 +169,15 @@ config:
                     access_key_id: $ui.accessKeyId,
                     user_name: $ui.userName,
                     invoked_by: $ui.invokedBy,
+
+                    # Present when the caller is an IAM Identity Center user
+                    # (userIdentity.type "IdentityCenterUser"); identifies the
+                    # Identity Center user the call was made on behalf of.
+                    on_behalf_of: {
+                      user_id: $ui.onBehalfOf.userId,
+                      identity_store_arn: $ui.onBehalfOf.identityStoreArn
+                    },
+
                     session_context: {
                       mfa_authenticated: $sc.attributes.mfaAuthenticated,
                       creation_date: $sc.attributes.creationDate,

--- a/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml
@@ -53,6 +53,13 @@ config:
             if ($s | type) == "string" and $s != "HIDDEN_DUE_TO_SECURITY_REASONS"
             then $s else null end;
 
+          # sourceIdentity is the original identity behind an assumed role. Only
+          # present when STS is configured to require it. requestParameters
+          # and responseElements are not always objects, hence the type guard.
+          def sid($o):
+            if ($o | type) == "object" then real_name($o.sourceIdentity)
+            else null end;
+
           def prune:
             walk(
               if type == "object" then
@@ -101,6 +108,9 @@ config:
 
           | ( $r.userIdentity // {} ) as $ui
           | ( $ui.sessionContext // {} ) as $sc
+          | ( sid($sc)
+              // sid($r.requestParameters)
+              // sid($r.responseElements) ) as $source_identity
 
           | {
               ecs: { version: "8.0.0" },
@@ -157,6 +167,7 @@ config:
               related: {
                 ip: ( if is_ip($r.sourceIPAddress) then [$r.sourceIPAddress] else [] end ),
                 user: ( [ $user_name,
+                          $source_identity,
                           real_name($ui.userName),
                           real_name($sc.sessionIssuer.userName) ]
                         | map(select(. != null)) | unique )
@@ -209,6 +220,7 @@ config:
                     session_context: {
                       mfa_authenticated: $sc.attributes.mfaAuthenticated,
                       creation_date: $sc.attributes.creationDate,
+                      source_identity: $sc.sourceIdentity,
                       session_issuer: {
                         type: $sc.sessionIssuer.type,
                         principal_id: $sc.sessionIssuer.principalId,

--- a/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
@@ -1,5 +1,5 @@
 name: "AWS CloudTrail to ECS v8.0.0 (Core)"
-description: "Normalizes individual AWS CloudTrail event records into the Elastic Common Schema (ECS) v8.0.0 core security fields (event, cloud, user, source, user_agent, related)."
+description: "Normalizes individual AWS CloudTrail event records into the Elastic Common Schema (ECS) v8.0.0 core security fields (event, cloud, user, source, user_agent, related), resolving the acting identity across every AWS sign-in form (IAM user, SAML/OIDC federation, IAM Identity Center users, and Identity Center role assumption)."
 author: "Monad"
 contributors:
   - "https://github.com/behobu"
@@ -35,15 +35,22 @@ config:
           #   .eventSource           -> event.provider
           #   .awsRegion             -> cloud.region
           #   .recipientAccountId    -> cloud.account.id
-          #   .userIdentity.userName -> user.name  (falls back to role name)
-          #   .userIdentity.principalId -> user.id
           #   .sourceIPAddress       -> source.ip / source.address
           #   .userAgent             -> user_agent.original
           #   errorCode / ConsoleLogin result -> event.outcome
+          #   the acting identity    -> user.name / user.id
+          #     (+ user.effective.* for the role it acted through)
+          #
+          # This variant emits ECS fields only - no aws.cloudtrail.* namespace
+          # and no event.original. Use the Comprehensive variant when an
+          # investigation needs the raw request/response detail, the issued
+          # access key id, or federation provider detail.
           # =================================================================
 
           # A CloudTrail sourceIPAddress is sometimes an AWS service name
-          # (e.g. "cloudtrail.amazonaws.com") rather than a client IP.
+          # (e.g. "cloudtrail.amazonaws.com") rather than a client IP. Guarding
+          # this matters for Elasticsearch: an `ip`-mapped field rejects the
+          # document outright when handed a hostname.
           def is_ip($s):
             ($s | type) == "string"
             and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
@@ -56,12 +63,18 @@ config:
             if ($s | type) == "string" and $s != "HIDDEN_DUE_TO_SECURITY_REASONS"
             then $s else null end;
 
-          # sourceIdentity is the original identity behind an assumed role. Only
-          # present when STS is configured to require it. requestParameters
-          # and responseElements are not always objects, hence the type guard.
-          def sid($o):
-            if ($o | type) == "object" then real_name($o.sourceIdentity)
-            else null end;
+          # requestParameters / responseElements / additionalEventData are not
+          # always JSON objects (a bare string aborts the whole transform when
+          # indexed), so every read of them goes through this guard.
+          def g($o; $k): if ($o | type) == "object" then $o[$k] else null end;
+
+          def sid($o): real_name(g($o; "sourceIdentity"));
+
+          # The session-name half of an assumed-role principalId
+          # ("AROAEXAMPLE:session-name" -> "session-name").
+          def session_name($p):
+            if ($p | type) == "string" and ($p | test(":"))
+            then ($p | sub("^[^:]*:"; "")) else null end;
 
           # Recursively drop null values and empty objects/arrays so the
           # emitted event stays compact.
@@ -75,29 +88,47 @@ config:
             );
 
           . as $r
+          | ( $r.userIdentity // {} ) as $ui
+          | ( $ui.sessionContext // {} ) as $sc
+          | ( $r.requestParameters ) as $rp
+          | ( $r.responseElements ) as $re
+          | ( $r.additionalEventData ) as $aed
 
           # ---- outcome ----------------------------------------------------
+          # additionalEventData.success covers the signin.amazonaws.com OAuth2
+          # events, which report failure there rather than via errorCode.
           | ( if ($r.errorCode // null) != null then "failure"
               elif ($r.eventName // "") == "ConsoleLogin"
-                then ( if ($r.responseElements.ConsoleLogin // "") == "Success"
+                then ( if (g($re; "ConsoleLogin") // "") == "Success"
                        then "success" else "failure" end )
+              elif (g($aed; "success") // "") == "false" then "failure"
               else "success" end ) as $outcome
 
-          # ---- event.category (heuristic; AWS has no explicit ECS category)
-          | ( if (($r.eventName // "") | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
+          # ---- event.category --------------------------------------------
+          # Every AWS sign-in form must land in `authentication`, because that
+          # is what SIEM detection content keys on:
+          #   - IAM user / root console password sign-in .. ConsoleLogin
+          #   - SAML or OIDC federated role assumption ... AssumeRoleWith*
+          #   - plain / chained role assumption .......... AssumeRole, AssumeRoot
+          #   - IAM Identity Center sign-in and tokens ... sso*/signin* events
+          | ( if (($r.eventName // "") | test("^(ConsoleLogin|SwitchRole|ExitRole|RenewRole|CheckMfa|AssumeRole|AssumeRoot|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
                 then ["authentication"]
               # IAM Identity Center sign-in and token/credential issuance.
               # This MUST be tested before the eventSource "iam" rule below,
               # which would otherwise swallow every sso./signin. event.
               elif (($r.eventSource // "") | test("^(sso|sso-oidc|signin|identitystore)\\."))
-                   and (($r.eventName // "") | test("^(Authenticate|UserAuthentication|CredentialChallenge|CredentialVerification|Federate|CreateToken|CreateTokenWithIAM|StartDeviceAuthorization|Authorize|GetRoleCredentials|SSOSignIn)$"))
+                   and (($r.eventName // "") | test("^(Authenticate|UserAuthentication|CredentialChallenge|CredentialVerification|Federate|CreateToken|CreateTokenWithIAM|StartDeviceAuthorization|Authorize|AuthorizeOAuth2Access|CreateOAuth2Token|GetRoleCredentials|SSOSignIn)$"))
                 then ["authentication"]
               elif ($r.eventSource // "") | test("^(iam|sso|signin)\\.")
                 then ["iam"]
               else ["configuration"] end ) as $category
 
           # ---- event.type (ECS allowed values) ---------------------------
-          | ( if ($r.eventName // "") == "ConsoleLogin" then ["start"]
+          # An authentication event is a session beginning, so it takes
+          # `start` rather than `access`. ECS pairs category=authentication
+          # with type=start/end/info, and detection content expects `start`.
+          | ( if ($r.eventName // "") == "ExitRole" then ["end"]
+              elif $category == ["authentication"] then ["start"]
               elif ($r.readOnly // false) == true then ["access"]
               elif (($r.eventName // "") | test("^(Create|Add|Enable|Register|Put|Allocate|Import|Run|Provision|Attach|Associate)"))
                 then ["creation"]
@@ -107,22 +138,36 @@ config:
                 then ["change"]
               else ["info"] end ) as $type
 
-          # ---- user.name (role name for assumed-role sessions) -----------
-          | ( real_name($r.userIdentity.userName)
-              // real_name($r.userIdentity.sessionContext.sessionIssuer.userName)
-              # IAM Identity Center no longer emits userIdentity.userName or
-              # principalId. The username is emitted once per successful
-              # sign-in under additionalEventData.UserName instead.
-              // real_name($r.additionalEventData.UserName) ) as $user_name
-
-          # ---- sourceIdentity: original identity behind an assumed role ---
-          | ( sid($r.userIdentity.sessionContext)
-              // sid($r.requestParameters)
-              // sid($r.responseElements) ) as $source_identity
-
-          # ---- role name of an assumed-role session (the effective identity)
-          | ( real_name($r.userIdentity.sessionContext.sessionIssuer.userName) )
-              as $issuer_name
+          # ---- IDENTITY RESOLUTION ---------------------------------------
+          # CloudTrail puts the acting identity in a different place for each
+          # sign-in form, and for a plain assumed-role session it supplies no
+          # human at all. Resolved most-authoritative first:
+          #
+          #  1. sourceIdentity ....... the originating human, when STS is
+          #       configured to require it. Survives role chaining.
+          #  2. Identity Center role assumption (what a mature setup does:
+          #       IdP -> Identity Center -> permission set). userIdentity.type
+          #       is "AssumedRole" and onBehalfOf sits ALONGSIDE principalId,
+          #       whose session-name half is the Identity Center username.
+          #  3. additionalEventData.UserName .. Identity Center sign-in events
+          #       (CredentialChallenge / UserAuthentication). AWS documents
+          #       this as the only username source for Identity Center.
+          #  4. userIdentity.userName ... IAMUser (console password sign-in),
+          #       SAMLUser (the saml:sub), WebIdentityUser (the OIDC user id),
+          #       Root (the account alias).
+          #  5. sessionIssuer.userName .. last resort: the ROLE name, not a
+          #       person. Only used when nothing above identifies a human.
+          | ( g($ui.onBehalfOf; "userId") ) as $idc_user_id
+          | ( if $idc_user_id != null then session_name($ui.principalId)
+              else null end ) as $idc_name
+          | ( sid($sc) // sid($rp) // sid($re) ) as $source_identity
+          | ( $source_identity
+              // $idc_name
+              // real_name(g($aed; "UserName"))
+              // real_name($ui.userName) ) as $actor
+          # The role whose privileges are in effect. Null for non-session
+          # callers (IAM user, SAML/OIDC assume calls, Identity Center users).
+          | ( real_name($sc.sessionIssuer.userName) ) as $role_name
 
           | {
               ecs: { version: "8.0.0" },
@@ -144,35 +189,33 @@ config:
               cloud: {
                 provider: "aws",
                 region: $r.awsRegion,
-                account: { id: ($r.recipientAccountId // $r.userIdentity.accountId) }
+                account: { id: ($r.recipientAccountId // $ui.accountId) }
               },
 
               # ECS models user.* as the identity that INITIATED the action and
               # user.effective.* as the identity whose privileges were used -
-              # the `sudo` model. When STS is configured to require a
-              # sourceIdentity, an assumed-role call gives us both: the human
-              # initiated it, the role's privileges carried it out.
+              # the `sudo` model. Where CloudTrail gives us both a human and
+              # the role they acted through, that maps exactly.
               #
-              # NOTE this makes user.name intentionally bimodal - the human
-              # where sourceIdentity is configured, otherwise the role or IAM
-              # user name, which is the only identity CloudTrail supplies.
-              # user.effective.* is populated ONLY when it differs from
-              # user.*, so it never merely duplicates it.
+              # NOTE user.name is intentionally bimodal: the human wherever one
+              # is identifiable (see IDENTITY RESOLUTION above), otherwise the
+              # role name, which is the only identity CloudTrail supplies for a
+              # plain assumed-role session. user.effective.* is populated ONLY
+              # when it differs from user.*, so it never merely duplicates it.
               user: (
-                if $source_identity != null and $issuer_name != null then {
-                  name: $source_identity,
-                  # CloudTrail carries no id for the source identity itself;
-                  # the role session principal becomes the effective id.
+                if $actor != null and $role_name != null then {
+                  # Identity Center supplies a stable, immutable user id; other
+                  # forms carry no id for the human, so user.id is omitted
+                  # rather than filled with the role session principal.
+                  id: $idc_user_id,
+                  name: $actor,
                   effective: {
-                    id: $r.userIdentity.principalId,
-                    name: $issuer_name
+                    id: $ui.principalId,
+                    name: $role_name
                   }
                 } else {
-                  # IdentityCenterUser events (and Identity Center events typed
-                  # "Unknown") carry no principalId; the Identity Store user id
-                  # in onBehalfOf is the only stable identifier available.
-                  id: ($r.userIdentity.principalId // $r.userIdentity.onBehalfOf.userId),
-                  name: ($source_identity // $user_name)
+                  id: ($idc_user_id // $ui.principalId),
+                  name: ($actor // $role_name)
                 } end
               ),
 
@@ -185,7 +228,16 @@ config:
 
               related: {
                 ip: ( if is_ip($r.sourceIPAddress) then [$r.sourceIPAddress] else [] end ),
-                user: ( [ $user_name, $source_identity ]
+                # Every identifier for the actor seen anywhere on the event, so
+                # a single related.user search finds the activity whichever
+                # sign-in form produced it.
+                user: ( [ $actor,
+                          $role_name,
+                          $source_identity,
+                          $idc_name,
+                          real_name($ui.userName),
+                          real_name(g($aed; "UserName")),
+                          real_name(g($re; "subject")) ]
                         | map(select(. != null)) | unique )
               }
             }

--- a/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
@@ -56,6 +56,13 @@ config:
             if ($s | type) == "string" and $s != "HIDDEN_DUE_TO_SECURITY_REASONS"
             then $s else null end;
 
+          # sourceIdentity is the original identity behind an assumed role. Only
+          # present when STS is configured to require it. requestParameters
+          # and responseElements are not always objects, hence the type guard.
+          def sid($o):
+            if ($o | type) == "object" then real_name($o.sourceIdentity)
+            else null end;
+
           # Recursively drop null values and empty objects/arrays so the
           # emitted event stays compact.
           def prune:
@@ -108,6 +115,11 @@ config:
               # sign-in under additionalEventData.UserName instead.
               // real_name($r.additionalEventData.UserName) ) as $user_name
 
+          # ---- sourceIdentity: original identity behind an assumed role ---
+          | ( sid($r.userIdentity.sessionContext)
+              // sid($r.requestParameters)
+              // sid($r.responseElements) ) as $source_identity
+
           | {
               ecs: { version: "8.0.0" },
 
@@ -148,7 +160,8 @@ config:
 
               related: {
                 ip: ( if is_ip($r.sourceIPAddress) then [$r.sourceIPAddress] else [] end ),
-                user: ( [ $user_name ] | map(select(. != null)) )
+                user: ( [ $user_name, $source_identity ]
+                        | map(select(. != null)) | unique )
               }
             }
           | prune

--- a/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
@@ -1,0 +1,130 @@
+name: "AWS CloudTrail to ECS v8.0.0 (Core)"
+description: "Normalizes individual AWS CloudTrail event records into the Elastic Common Schema (ECS) v8.0.0 core security fields (event, cloud, user, source, user_agent, related)."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudtrail"
+tags:
+  - "v8.0.0"
+  - "ecs"
+  - "aws"
+  - "cloudtrail"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # AWS CloudTrail  ->  ECS v8.0.0  (CORE security fields)
+          #
+          # Input: ONE CloudTrail event record per invocation, as emitted by
+          #   the Monad `cloudtrail` input connector. (For the S3/SQS
+          #   connector `aws-sqs-s3-cloudtrail`, explode `.Records[]` in an
+          #   upstream transform first — it emits chunked Records arrays.)
+          #
+          # Field mappings:
+          #   .eventTime             -> @timestamp
+          #   .eventName             -> event.action
+          #   .eventID               -> event.id
+          #   .eventSource           -> event.provider
+          #   .awsRegion             -> cloud.region
+          #   .recipientAccountId    -> cloud.account.id
+          #   .userIdentity.userName -> user.name  (falls back to role name)
+          #   .userIdentity.principalId -> user.id
+          #   .sourceIPAddress       -> source.ip / source.address
+          #   .userAgent             -> user_agent.original
+          #   errorCode / ConsoleLogin result -> event.outcome
+          # =================================================================
+
+          # A CloudTrail sourceIPAddress is sometimes an AWS service name
+          # (e.g. "cloudtrail.amazonaws.com") rather than a client IP.
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          # Recursively drop null values and empty objects/arrays so the
+          # emitted event stays compact.
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+
+          # ---- outcome ----------------------------------------------------
+          | ( if ($r.errorCode // null) != null then "failure"
+              elif $r.eventName == "ConsoleLogin"
+                then ( if ($r.responseElements.ConsoleLogin // "") == "Success"
+                       then "success" else "failure" end )
+              else "success" end ) as $outcome
+
+          # ---- event.category (heuristic; AWS has no explicit ECS category)
+          | ( if ($r.eventName | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
+                then ["authentication"]
+              elif ($r.eventSource // "") | test("^(iam|sso|signin)\\.")
+                then ["iam"]
+              else ["configuration"] end ) as $category
+
+          # ---- event.type (ECS allowed values) ---------------------------
+          | ( if $r.eventName == "ConsoleLogin" then ["start"]
+              elif ($r.readOnly // false) == true then ["access"]
+              elif ($r.eventName | test("^(Create|Add|Enable|Register|Put|Allocate|Import|Run|Provision|Attach|Associate)"))
+                then ["creation"]
+              elif ($r.eventName | test("^(Delete|Remove|Deregister|Disable|Detach|Disassociate|Terminate|Revoke)"))
+                then ["deletion"]
+              elif ($r.eventName | test("^(Update|Modify|Set|Change|Replace)"))
+                then ["change"]
+              else ["info"] end ) as $type
+
+          # ---- user.name (role name for assumed-role sessions) -----------
+          | ( $r.userIdentity.userName
+              // $r.userIdentity.sessionContext.sessionIssuer.userName ) as $user_name
+
+          | {
+              ecs: { version: "8.0.0" },
+
+              "@timestamp": $r.eventTime,
+
+              event: {
+                kind: "event",
+                module: "aws",
+                dataset: "aws.cloudtrail",
+                provider: $r.eventSource,
+                action: $r.eventName,
+                id: $r.eventID,
+                category: $category,
+                type: $type,
+                outcome: $outcome
+              },
+
+              cloud: {
+                provider: "aws",
+                region: $r.awsRegion,
+                account: { id: ($r.recipientAccountId // $r.userIdentity.accountId) }
+              },
+
+              user: {
+                id: $r.userIdentity.principalId,
+                name: $user_name
+              },
+
+              source: {
+                address: $r.sourceIPAddress,
+                ip: ( if is_ip($r.sourceIPAddress) then $r.sourceIPAddress else null end )
+              },
+
+              user_agent: { original: $r.userAgent },
+
+              related: {
+                ip: ( if is_ip($r.sourceIPAddress) then [$r.sourceIPAddress] else [] end ),
+                user: ( [ $user_name ] | map(select(. != null)) )
+              }
+            }
+          | prune

--- a/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
@@ -48,6 +48,14 @@ config:
             ($s | type) == "string"
             and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
 
+          # CloudTrail replaces a user name with this sentinel when a console
+          # sign-in fails because of bad username input, and IAM Identity
+          # Center does the same for additionalEventData.UserName. It is a
+          # redaction marker, not an identity - never surface it as user.name.
+          def real_name($s):
+            if ($s | type) == "string" and $s != "HIDDEN_DUE_TO_SECURITY_REASONS"
+            then $s else null end;
+
           # Recursively drop null values and empty objects/arrays so the
           # emitted event stays compact.
           def prune:
@@ -71,6 +79,12 @@ config:
           # ---- event.category (heuristic; AWS has no explicit ECS category)
           | ( if (($r.eventName // "") | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
                 then ["authentication"]
+              # IAM Identity Center sign-in and token/credential issuance.
+              # This MUST be tested before the eventSource "iam" rule below,
+              # which would otherwise swallow every sso./signin. event.
+              elif (($r.eventSource // "") | test("^(sso|sso-oidc|signin|identitystore)\\."))
+                   and (($r.eventName // "") | test("^(Authenticate|UserAuthentication|CredentialChallenge|CredentialVerification|Federate|CreateToken|CreateTokenWithIAM|StartDeviceAuthorization|Authorize|GetRoleCredentials|SSOSignIn)$"))
+                then ["authentication"]
               elif ($r.eventSource // "") | test("^(iam|sso|signin)\\.")
                 then ["iam"]
               else ["configuration"] end ) as $category
@@ -87,8 +101,12 @@ config:
               else ["info"] end ) as $type
 
           # ---- user.name (role name for assumed-role sessions) -----------
-          | ( $r.userIdentity.userName
-              // $r.userIdentity.sessionContext.sessionIssuer.userName ) as $user_name
+          | ( real_name($r.userIdentity.userName)
+              // real_name($r.userIdentity.sessionContext.sessionIssuer.userName)
+              # IAM Identity Center no longer emits userIdentity.userName or
+              # principalId. The username is emitted once per successful
+              # sign-in under additionalEventData.UserName instead.
+              // real_name($r.additionalEventData.UserName) ) as $user_name
 
           | {
               ecs: { version: "8.0.0" },
@@ -114,7 +132,10 @@ config:
               },
 
               user: {
-                id: $r.userIdentity.principalId,
+                # IdentityCenterUser events (and Identity Center events typed
+                # "Unknown") carry no principalId; the Identity Store user id
+                # in onBehalfOf is the only stable identifier available.
+                id: ($r.userIdentity.principalId // $r.userIdentity.onBehalfOf.userId),
                 name: $user_name
               },
 

--- a/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
@@ -22,8 +22,11 @@ config:
           #
           # Input: ONE CloudTrail event record per invocation, as emitted by
           #   the Monad `cloudtrail` input connector. (For the S3/SQS
-          #   connector `aws-sqs-s3-cloudtrail`, explode `.Records[]` in an
-          #   upstream transform first — it emits chunked Records arrays.)
+          #   connector `aws-sqs-s3-cloudtrail` this depends on its Chunking
+          #   Mode: `per_record` already emits one bare event per record and
+          #   needs nothing extra, while `by_size` — the default — emits the
+          #   CloudTrail envelope with `Records` chunked, so explode
+          #   `.Records[]` in an upstream transform first.)
           #
           # Field mappings:
           #   .eventTime             -> @timestamp
@@ -60,26 +63,26 @@ config:
 
           # ---- outcome ----------------------------------------------------
           | ( if ($r.errorCode // null) != null then "failure"
-              elif $r.eventName == "ConsoleLogin"
+              elif ($r.eventName // "") == "ConsoleLogin"
                 then ( if ($r.responseElements.ConsoleLogin // "") == "Success"
                        then "success" else "failure" end )
               else "success" end ) as $outcome
 
           # ---- event.category (heuristic; AWS has no explicit ECS category)
-          | ( if ($r.eventName | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
+          | ( if (($r.eventName // "") | test("^(ConsoleLogin|AssumeRole|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
                 then ["authentication"]
               elif ($r.eventSource // "") | test("^(iam|sso|signin)\\.")
                 then ["iam"]
               else ["configuration"] end ) as $category
 
           # ---- event.type (ECS allowed values) ---------------------------
-          | ( if $r.eventName == "ConsoleLogin" then ["start"]
+          | ( if ($r.eventName // "") == "ConsoleLogin" then ["start"]
               elif ($r.readOnly // false) == true then ["access"]
-              elif ($r.eventName | test("^(Create|Add|Enable|Register|Put|Allocate|Import|Run|Provision|Attach|Associate)"))
+              elif (($r.eventName // "") | test("^(Create|Add|Enable|Register|Put|Allocate|Import|Run|Provision|Attach|Associate)"))
                 then ["creation"]
-              elif ($r.eventName | test("^(Delete|Remove|Deregister|Disable|Detach|Disassociate|Terminate|Revoke)"))
+              elif (($r.eventName // "") | test("^(Delete|Remove|Deregister|Disable|Detach|Disassociate|Terminate|Revoke)"))
                 then ["deletion"]
-              elif ($r.eventName | test("^(Update|Modify|Set|Change|Replace)"))
+              elif (($r.eventName // "") | test("^(Update|Modify|Set|Change|Replace)"))
                 then ["change"]
               else ["info"] end ) as $type
 

--- a/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
+++ b/ecs/v8.0.0/aws/aws-cloudtrail-core.yaml
@@ -120,6 +120,10 @@ config:
               // sid($r.requestParameters)
               // sid($r.responseElements) ) as $source_identity
 
+          # ---- role name of an assumed-role session (the effective identity)
+          | ( real_name($r.userIdentity.sessionContext.sessionIssuer.userName) )
+              as $issuer_name
+
           | {
               ecs: { version: "8.0.0" },
 
@@ -143,13 +147,34 @@ config:
                 account: { id: ($r.recipientAccountId // $r.userIdentity.accountId) }
               },
 
-              user: {
-                # IdentityCenterUser events (and Identity Center events typed
-                # "Unknown") carry no principalId; the Identity Store user id
-                # in onBehalfOf is the only stable identifier available.
-                id: ($r.userIdentity.principalId // $r.userIdentity.onBehalfOf.userId),
-                name: $user_name
-              },
+              # ECS models user.* as the identity that INITIATED the action and
+              # user.effective.* as the identity whose privileges were used -
+              # the `sudo` model. When STS is configured to require a
+              # sourceIdentity, an assumed-role call gives us both: the human
+              # initiated it, the role's privileges carried it out.
+              #
+              # NOTE this makes user.name intentionally bimodal - the human
+              # where sourceIdentity is configured, otherwise the role or IAM
+              # user name, which is the only identity CloudTrail supplies.
+              # user.effective.* is populated ONLY when it differs from
+              # user.*, so it never merely duplicates it.
+              user: (
+                if $source_identity != null and $issuer_name != null then {
+                  name: $source_identity,
+                  # CloudTrail carries no id for the source identity itself;
+                  # the role session principal becomes the effective id.
+                  effective: {
+                    id: $r.userIdentity.principalId,
+                    name: $issuer_name
+                  }
+                } else {
+                  # IdentityCenterUser events (and Identity Center events typed
+                  # "Unknown") carry no principalId; the Identity Store user id
+                  # in onBehalfOf is the only stable identifier available.
+                  id: ($r.userIdentity.principalId // $r.userIdentity.onBehalfOf.userId),
+                  name: ($source_identity // $user_name)
+                } end
+              ),
 
               source: {
                 address: $r.sourceIPAddress,


### PR DESCRIPTION
## What

Adds the same two AWS **CloudTrail → ECS** transforms retargeted to **ECS v8.0.0**, for deployments still on the 8.0 line:

- `ecs/v8.0.0/aws/aws-cloudtrail-core.yaml`
- `ecs/v8.0.0/aws/aws-cloudtrail-comprehensive.yaml`

## Relationship to the v8.11.0 PR

Same jq logic as the v8.11.0 pair (#32) — a **clean version bump**, no field surgery. This branch is based on `main` and is **independent** of #32, so the two can review/merge separately. The two trees are byte-identical apart from their version strings, verified by diffing with version lines filtered out.

**Every ECS field used exists in 8.0.0.** Verified programmatically against Elastic's generated field list for `v8.0.0` — all 27 emitted ECS fields are present, and the `event.category` / `event.type` values used (`authentication`, `iam`, `configuration` / `start`, `access`, `creation`, `deletion`, `change`, `info`) are all in 8.0.0's allowed-value sets. No field needs version-specific treatment, which is why the logic can be identical.

## Validation

**37 real CloudTrail records** run through both files, from two sources. No failures on either file. `ecs.version` is `8.0.0` throughout — confirmed no cross-contamination from the 8.11.0 tree.

### 1. Live pipeline records (30)

Pulled off the input node of the **live `cloudtrail` input in the jfrog demo org** — `use_synthetic_data: false`, real S3 bucket, and an **organization trail** (4 distinct `recipientAccountId`s, 6 regions including us-east-1).

- **30/30 pass** on each file. 20 distinct `eventName` across 12 distinct `eventSource`.
- Records arrive as **flat single events** (no `Records` wrapper), confirming the connector contract.
- **All 25 ECS-namespace output paths are valid ECS fields in 8.0.0.** Plus 59 `aws.cloudtrail.*` vendor paths.

Real-world shapes verified to map correctly: `userIdentity.type` `AssumedRole` (8+) and `AWSService` (1 → `user` block pruned), `tlsDetails` (3 → `tls.version`/`cipher`/`client.server_name`), `resources[]` (2 → `ARN`→`arn`, `accountId`→`account_id`), non-IP `sourceIPAddress` (3 → `is_ip` guard holds, `source.ip` omitted), `sessionContext` (8).

### 2. Real failure records (7)

The live pipeline sample contained no failed calls, so these were sourced separately from CloudTrail Event History (`lookup-events`) rather than through the connector — genuine `InternalFailure` records on `CreateServiceLinkedChannel`, all carrying an `errorMessage`.

- **7/7 pass**, `event.outcome: "failure"` on all.
- `error.code` **7/7** and `error.message` **7/7** populated in comprehensive.
- Also covers the `creation` event type.

Combined live branch coverage: **outcomes** success + failure; **categories** configuration, iam, authentication; **types** access, change, creation.

### 3. Synthetic matrix

17 cases for shapes real traffic doesn't produce: empty object, missing/null `eventName`, `by_size` envelope, IPv6 and service-name `sourceIPAddress`, ConsoleLogin success/failure/no-response, assumed-role name fallback, `readOnly`, `resources`, and each category/type branch. **0 failures.**

## Fixes found during validation

1. **`eventName` guard (`e67123f`).** `$category` and `$type` piped `$r.eventName` straight into `test()`, which hard-errors when `eventName` is absent or null. Realistic trigger: feeding `aws-sqs-s3-cloudtrail`'s default `by_size` output in without exploding `.Records[]` first. Now guarded with `// ""`; output on records carrying `eventName` is byte-identical before and after.

2. **`userIdentity.onBehalfOf` mapping (`63b6d68`).** Live records carried this field and the comprehensive transform dropped it. AWS sets it for IAM Identity Center callers — the only attribution for SSO-initiated activity. Now mapped to `aws.cloudtrail.user_identity.on_behalf_of` (`user_id`, `identity_store_arn`), field names per AWS's `userIdentity` reference. Absent → pruned, no empty object.

3. Header comment corrected: `aws-sqs-s3-cloudtrail`'s Chunking Mode decides the shape — `per_record` needs nothing extra, only `by_size` (the default) needs the `.Records[]` explode.

## Known coverage limits

- **`ConsoleLogin` is not testable in our AWS org.** Monad authenticates via IAM Identity Center, which doesn't emit `ConsoleLogin` in the target account — confirmed zero such events across 4 accounts over a 7-day window. That branch is covered synthetically only; it remains correct for customers using IAM console sign-in.
- The `deletion` event type is likewise synthetic-only — no delete calls appeared in the sampled window.

## Note on version choice

ECS is currently at **v9.4.0**, and this repo otherwise only carries a `v8.11.0` tree — so this PR adds an older version directory. Worth confirming there's a consumer actually pinned to the 8.0 line before merging; otherwise a v9.x variant would likely serve more users.

Refs: CS-135
