### PR TITLE
feat(ecs): vendor→ECS v9.5.0 transforms

### DIFF
--- a/ecs/v9.5.0/alienvault/alienvault-otx-indicators.yaml
+++ b/ecs/v9.5.0/alienvault/alienvault-otx-indicators.yaml
@@ -1,0 +1,125 @@
+name: "AlienVault OTX Indicators to ECS v9.5.0"
+description: "Normalizes AlienVault OTX IOC indicator records (enriched with parent-pulse threat context) into Elastic Common Schema (ECS) v9.5.0 threat-intelligence fields (event, threat.indicator, threat.feed, threat.group, threat.software, threat.technique, related)."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "alienvault-otx-indicators"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "alienvault"
+  - "otx-indicators"
+  - "threat-intel"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # AlienVault OTX Indicators  ->  ECS v9.5.0  (threat intelligence)
+          #
+          # Input: ONE OTX indicator record per invocation (indicator/type/
+          #   created/role/...) with a nested parent-pulse object under
+          #   `.pulse`, as emitted by the Monad `alienvault-otx-indicators`
+          #   connector.
+          #
+          # A threat-intel indicator maps to event.kind=enrichment,
+          # event.category=[threat], event.type=[indicator] and the
+          # threat.indicator.* field set.
+          # =================================================================
+
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$")
+                 or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          . as $r
+          | ($r.type // "") as $itype
+          | ($r.pulse // {}) as $p
+          | ($r.indicator // "") as $ioc
+
+          # OTX indicator type -> ECS threat.indicator.type value
+          | ( { "IPv4":"ipv4-addr", "IPv6":"ipv6-addr", "CIDR":"ipv4-addr",
+                "domain":"domain-name", "hostname":"domain-name",
+                "URL":"url", "URI":"url",
+                "FileHash-MD5":"file", "FileHash-SHA1":"file",
+                "FileHash-SHA256":"file", "FileHash-PEHASH":"file",
+                "FileHash-IMPHASH":"file", "FileHash-SSDEEP":"file",
+                "email":"email-addr",
+                "FilePath":"file", "Mutex":"process",
+                "CVE":"software" }[$itype] // "unknown" ) as $ecs_type
+
+          | {
+              "@timestamp": ($r.created // $p.created),
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "enrichment",
+                "category": ["threat"],
+                "type": ["indicator"],
+                "outcome": "unknown",
+                "provider": "AlienVault OTX",
+                "created": ($r.created // null),
+                "module": "alienvault_otx"
+              },
+
+              "message": (($p.name // "OTX indicator")
+                          + " — " + $itype + " " + $ioc),
+              "tags": ($p.tags // null),
+
+              "threat": {
+                "feed": {
+                  "name": "AlienVault OTX",
+                  "reference": ($p.references[0]? // null)
+                },
+                "indicator": {
+                  "type": $ecs_type,
+                  "name": $ioc,
+                  "description": ($r.description // $r.content // null),
+                  "provider": ($p.author_name // "AlienVault"),
+                  "reference": ($p.references[0]? // null),
+                  "first_seen": ($r.created // null),
+                  "last_seen": ($p.modified // null),
+                  "marking": {
+                    "tlp": (if ($p.tlp // "") == "" then null
+                            else ($p.tlp | ascii_upcase) end)
+                  },
+                  "confidence": (if ($r.is_active // 0) == 1 then "High" else "Not Specified" end),
+                  "ip": (if ($ecs_type == "ipv4-addr" or $ecs_type == "ipv6-addr")
+                            and is_ip($ioc) then $ioc else null end),
+                  "url": (if $ecs_type == "url"
+                          then { "full": $ioc, "original": $ioc } else null end),
+                  "email": (if $ecs_type == "email-addr"
+                            then { "address": $ioc } else null end),
+                  "file": (
+                    if $itype == "FileHash-MD5" then { "hash": { "md5": $ioc } }
+                    elif $itype == "FileHash-SHA1" then { "hash": { "sha1": $ioc } }
+                    elif $itype == "FileHash-SHA256" then { "hash": { "sha256": $ioc } }
+                    else null end)
+                },
+                "group": (if ($p.adversary // "") == "" then null
+                          else { "name": $p.adversary } end),
+                "software": (if ($p.malware_families // []) | length > 0
+                             then { "name": $p.malware_families[0], "type": "Malware" }
+                             else null end),
+                "technique": (if ($p.attack_ids // []) | length > 0
+                              then { "id": $p.attack_ids } else null end)
+              },
+
+              "related": {
+                "ip": (if ($ecs_type == "ipv4-addr" or $ecs_type == "ipv6-addr")
+                          and is_ip($ioc) then [$ioc] else null end),
+                "hosts": (if $ecs_type == "domain-name" then [$ioc] else null end)
+              }
+            }
+          # Single end-of-pipeline recursive prune: ES rejects nulls, and the
+          # doc is deeply nested. Drops null, {}, [].
+          | walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            )

--- a/ecs/v9.5.0/atlassian/atlassian-jira-audit-logs.yaml
+++ b/ecs/v9.5.0/atlassian/atlassian-jira-audit-logs.yaml
@@ -1,0 +1,109 @@
+name: "Atlassian Jira Audit Logs to ECS v9.5.0"
+description: "Normalizes Atlassian Jira audit log records into the Elastic Common Schema (ECS) v9.5.0 core security fields (event, user, source, related, plus the jira.* vendor namespace for the acted-on object and changed values)."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "atlassian-jira-audit-logs"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "atlassian"
+  - "jira"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # Atlassian Jira Audit Logs  ->  ECS v9.5.0
+          # Input: ONE Jira auditing REST record per invocation
+          #   (/rest/api/3/auditing/record).
+          #
+          #   .created        -> @timestamp
+          #   .summary        -> event.action
+          #   .id             -> event.id
+          #   .category       -> event categorization (iam)
+          #   .remoteAddress  -> source.ip / source.address / related.ip
+          #   .authorKey      -> user.name / related.user
+          #   .authorAccountId-> user.id
+          #   objectItem      -> target user/group + jira.object.*
+          # =================================================================
+          # An ES `ip` field rejects a non-IP document; guard remoteAddress.
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          . as $r
+
+          # Jira `created` = "2026-08-11T14:52:07.913+0000"; ES date parses
+          # ISO-8601, but normalize the numeric offset to Z for consistency.
+          | ( $r.created
+              | sub("\\.[0-9]+"; "")
+              | sub("([+-][0-9]{2}:?[0-9]{2}|Z)$"; "")
+              | . + "Z" ) as $ts
+
+          | ($r.summary // "" | ascii_downcase) as $s
+          | (if   ($s | test("creat|added|grant")) then "creation"
+             elif ($s | test("delet|remov|revok"))  then "deletion"
+             elif ($s | test("group")) then "group"
+             elif ($s | test("user"))  then "user"
+             else "change" end) as $etype
+
+          | ($r.objectItem // {}) as $obj
+          | ($r.remoteAddress) as $ip
+          | {
+              "@timestamp": $ts,
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "event",
+                "category": ["iam"],
+                "type": [$etype],
+                "outcome": "success",
+                "action": $r.summary,
+                "id": ($r.id | tostring),
+                "provider": $r.eventSource,
+                "module": "jira",
+                "dataset": "jira.audit"
+              },
+
+              "message": $r.description,
+
+              "user": ( {
+                "name": $r.authorKey,
+                "id":   $r.authorAccountId
+              } | with_entries(select(.value != null)) ),
+
+              "source": ( {
+                "ip":      (if is_ip($ip) then $ip else null end),
+                "address": $ip
+              } | with_entries(select(.value != null)) ),
+
+              "related": ( {
+                "user": ( [ $r.authorKey,
+                            (if ($obj.typeName // "") == "USER" then $obj.name else null end) ]
+                          | map(select(. != null)) | unique ),
+                "ip":   ( [ (if is_ip($ip) then $ip else null end) ]
+                          | map(select(. != null)) | unique )
+              } | with_entries(select(.value | length > 0)) ),
+
+              # Vendor namespace (allowed by ECS for custom data): the acted-on
+              # object, the group/permission category, and changed values.
+              "jira": ( {
+                "category": $r.category,
+                "object": ( {
+                  "id":     (if ($obj.id == null) then null else ($obj.id | tostring) end),
+                  "name":   $obj.name,
+                  "type":   $obj.typeName,
+                  "parent": $obj.parentName
+                } | with_entries(select(.value != null)) ),
+                "changed_values":   (if ($r.changedValues // []) | length > 0 then ($r.changedValues | tojson) else null end),
+                "associated_items": (if ($r.associatedItems // []) | length > 0 then ($r.associatedItems | tojson) else null end)
+              } | with_entries(select(.value != null)) )
+            }
+
+          # Single end-of-pipeline prune: ES rejects nulls; drop empties.
+          | walk(if type == "object" then with_entries(select(.value != null and .value != {} and .value != [])) else . end)

--- a/ecs/v9.5.0/aws/aws-guardduty.yaml
+++ b/ecs/v9.5.0/aws/aws-guardduty.yaml
@@ -1,0 +1,162 @@
+name: "AWS GuardDuty Findings to ECS v9.5.0"
+description: "Normalizes Amazon GuardDuty finding records into Elastic Common Schema (ECS) v9.5.0 fields (event, cloud, host, source, destination, network, threat, rule, related), plus the aws.guardduty.* vendor namespace for finding detail."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-guardduty"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "aws"
+  - "guardduty"
+  - "intrusion_detection"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # AWS GuardDuty finding  ->  ECS v9.5.0
+          # Input: ONE GuardDuty finding record per invocation.
+          #
+          #   event.kind      = alert          (a detection notification)
+          #   event.category  = intrusion_detection
+          #   event.type      = denied (if blocked) else info
+          #   .updatedAt      -> @timestamp
+          #   .type           -> event.action / rule.name / threat.*
+          #   .id             -> event.id
+          #   .severity       -> event.severity (numeric)
+          #   remoteIpDetails -> source.{ip,port,geo,as}
+          #   localIpDetails / instance NIC -> destination / host
+          # =================================================================
+
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          def to_iso($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number"
+              then ($ts | todateiso8601)
+            else $ts end;
+
+          . as $r
+          | ($r.service // {}) as $svc
+          | ($svc.action // {}) as $act
+          | ($act.networkConnectionAction // {}) as $nca
+          | ($nca.remoteIpDetails // {}) as $remote
+          | ($remote.organization // {}) as $org
+          | ($remote.geoLocation // {}) as $geo
+          | ($r.resource // {}) as $res
+          | (($res.instanceDetails // {}).networkInterfaces[0] // {}) as $nic
+          | ($nca.localIpDetails // {}) as $local
+          | ($nca.blocked == true) as $blocked
+          | {
+              "@timestamp": (to_iso($r.updatedAt // $r.createdAt)),
+              "ecs": { "version": "9.5.0" },
+
+              "message": $r.title,
+
+              "event": {
+                "kind": "alert",
+                "category": [ "intrusion_detection" ],
+                "type": [ (if $blocked then "denied" else "info" end) ],
+                "outcome": "unknown",
+                "action": $r.type,
+                "id": $r.id,
+                "severity": $r.severity,
+                "provider": ($svc.serviceName // "guardduty"),
+                "module": "guardduty",
+                "dataset": "aws.guardduty",
+                "reason": $r.description,
+                "created": (to_iso($r.createdAt)),
+                "start": (to_iso($svc.eventFirstSeen)),
+                "end": (to_iso($svc.eventLastSeen)),
+                "url": ("https://console.aws.amazon.com/guardduty/home?region=" + ($r.region // "") + "#/findings?fId=" + ($r.id // ""))
+              },
+
+              "rule": {
+                "name": $r.type,
+                "description": $r.title,
+                "ruleset": "Amazon GuardDuty"
+              },
+
+              "cloud": {
+                "provider": "aws",
+                "region": $r.region,
+                "account": { "id": $r.accountId },
+                "availability_zone": (($res.instanceDetails // {}).availabilityZone),
+                "instance": { "id": (($res.instanceDetails // {}).instanceId) },
+                "machine": { "type": (($res.instanceDetails // {}).instanceType) }
+              },
+
+              "host": {
+                "id": (($res.instanceDetails // {}).instanceId),
+                "type": (($res.instanceDetails // {}).instanceType),
+                "ip": ( [ (if is_ip($nic.privateIpAddress) then $nic.privateIpAddress else empty end),
+                          (if is_ip($nic.publicIp) then $nic.publicIp else empty end) ] ),
+                "hostname": ($nic.privateDnsName)
+              },
+
+              "source": {
+                "ip": (if is_ip($remote.ipAddressV4) then $remote.ipAddressV4 else null end),
+                "address": ($remote.ipAddressV4),
+                "port": (($nca.remotePortDetails // {}).port),
+                "geo": {
+                  "country_name": (($remote.country // {}).countryName),
+                  "city_name": (($remote.city // {}).cityName),
+                  "location": ( if ($geo.lat != null and $geo.lon != null)
+                                then (($geo.lat | tostring) + "," + ($geo.lon | tostring)) else null end )
+                },
+                "as": {
+                  "number": (if $org.asn then ($org.asn | tonumber? // null) else null end),
+                  "organization": { "name": $org.asnOrg }
+                }
+              },
+
+              "destination": {
+                "ip": (if is_ip($local.ipAddressV4) then $local.ipAddressV4 else null end),
+                "address": ($local.ipAddressV4),
+                "port": (($nca.localPortDetails // {}).port)
+              },
+
+              "network": {
+                "transport": (if $nca.protocol then ($nca.protocol | ascii_downcase) else null end),
+                "direction": (if $nca.connectionDirection then ($nca.connectionDirection | ascii_downcase) else null end)
+              },
+
+              "threat": {
+                "framework": "MITRE ATT&CK",
+                "indicator": {
+                  "ip": (if is_ip($remote.ipAddressV4) then $remote.ipAddressV4 else null end),
+                  "type": (if is_ip($remote.ipAddressV4) then "ipv4-addr" else null end)
+                }
+              },
+
+              "related": {
+                "ip": ( [ (if is_ip($remote.ipAddressV4) then $remote.ipAddressV4 else empty end),
+                          (if is_ip($local.ipAddressV4) then $local.ipAddressV4 else empty end),
+                          (if is_ip($nic.privateIpAddress) then $nic.privateIpAddress else empty end),
+                          (if is_ip($nic.publicIp) then $nic.publicIp else empty end) ] | unique ),
+                "hosts": ( [ (($res.instanceDetails // {}).instanceId) ] | map(select(. != null)) | unique )
+              },
+
+              "aws": {
+                "guardduty": {
+                  "finding_id": $r.id,
+                  "finding_type": $r.type,
+                  "schema_version": $r.schemaVersion,
+                  "partition": $r.partition,
+                  "detector_id": $svc.detectorId,
+                  "resource_type": ($res.resourceType),
+                  "resource_role": $svc.resourceRole,
+                  "action_type": $act.actionType,
+                  "count": $svc.count,
+                  "archived": $svc.archived,
+                  "blocked": $nca.blocked
+                }
+              }
+            }
+          | walk(if type == "object" then with_entries(select(.value != null and .value != "" and .value != {} and .value != [])) else . end)

--- a/ecs/v9.5.0/aws/aws-security-hub-findings.yaml
+++ b/ecs/v9.5.0/aws/aws-security-hub-findings.yaml
@@ -1,0 +1,119 @@
+name: "AWS Security Hub Findings to ECS v9.5.0"
+description: "Maps AWS Security Hub findings (ASFF) into Elastic Common Schema (ECS) v9.5.0, covering event categorization (alert / intrusion_detection), rule.*, cloud.*, source/destination network, host.*, related.* and vulnerability.* field groups."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-security-hub-findings"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "aws"
+  - "security-hub"
+  - "findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Security Hub finding (ASFF) -> ECS v9.5.0 (nested).
+          # event.kind=alert; event.category=[intrusion_detection];
+          # event.type=[info]; event.outcome=unknown.
+          # One jq pass, bind-once, is_ip guard, related.* union, single prune.
+          # ---------------------------------------------------------------
+          def is_ip($s): ($s|type)=="string"
+            and ($s|test("^([0-9]{1,3}\\.){3}[0-9]{1,3}$") or ($s|test(":")));
+
+          . as $r
+          | ($r.Severity // {}) as $sev
+          | ($r.Network // {}) as $net
+          | ($r.Resources // []) as $res
+          | ($r.Remediation.Recommendation // {}) as $rem
+          | ([ $net.SourceIpV4, $net.DestinationIpV4,
+               ($res[]?.Details?.AwsEc2Instance?.IpV4Addresses[]?) ]
+             | map(select(is_ip(.))) | unique) as $ips
+          | {
+              "@timestamp": ($r.UpdatedAt // $r.CreatedAt),
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "alert",
+                "category": ["intrusion_detection"],
+                "type": ["info"],
+                "outcome": "unknown",
+                "id": $r.Id,
+                "provider": $r.ProductName,
+                "module": "security_hub",
+                "dataset": "aws.securityhub",
+                "severity": $sev.Normalized,
+                "created": $r.CreatedAt,
+                "start": $r.FirstObservedAt,
+                "end": $r.LastObservedAt,
+                "url": $r.SourceUrl,
+                "action": ($r.Types[0]?),
+                "reason": $r.Description,
+                "risk_score": $sev.Normalized
+              },
+
+              "message": $r.Title,
+
+              "rule": {
+                "id": $r.GeneratorId,
+                "name": ($r.Types[0]?),
+                "ruleset": $r.ProductName,
+                "reference": $rem.Url,
+                "description": $rem.Text
+              },
+
+              "cloud": {
+                "provider": "aws",
+                "account": { "id": $r.AwsAccountId },
+                "region": $r.Region
+              },
+
+              "organization": { "name": $r.CompanyName },
+
+              "source": (
+                if is_ip($net.SourceIpV4) then
+                  { "ip": $net.SourceIpV4, "port": $net.SourcePort }
+                else null end),
+              "destination": (
+                if is_ip($net.DestinationIpV4) then
+                  { "ip": $net.DestinationIpV4, "port": $net.DestinationPort }
+                else null end),
+              "network": (
+                if ($net.Protocol // $net.Direction) != null then
+                  { "transport": ($net.Protocol | ascii_downcase? // null),
+                    "direction": ($net.Direction | ascii_downcase? // null) }
+                else null end),
+
+              "host": (
+                ($res[] | select(.Type == "AwsEc2Instance") | .Details.AwsEc2Instance) as $ec2
+                | if $ec2 != null then
+                    { "type": $ec2.Type, "ip": ($ec2.IpV4Addresses // []) }
+                  else null end),
+
+              "related": {
+                "ip": $ips,
+                "hosts": ([ $res[]? | select(.Type=="AwsEc2Instance") | .Id ]
+                          | map(select(. != null)) | unique)
+              },
+
+              "tags": $r.Types,
+
+              "labels": {
+                "record_state": $r.RecordState,
+                "workflow_status": ($r.Workflow.Status?),
+                "compliance_status": ($r.Compliance.Status?),
+                "severity_label": $sev.Label
+              }
+            }
+            # Single end-of-pipeline prune (ES rejects nulls; drop {} and []).
+            | walk(
+                if type == "object" then
+                  with_entries(select(.value != null and .value != "" and .value != [] and .value != {}))
+                elif type == "array" then
+                  map(select(. != null))
+                else . end)

--- a/ecs/v9.5.0/aws/cloudtrail.yaml
+++ b/ecs/v9.5.0/aws/cloudtrail.yaml
@@ -1,0 +1,182 @@
+name: "AWS CloudTrail to ECS v9.5.0"
+description: "Normalizes individual AWS CloudTrail event records into the Elastic Common Schema (ECS) v9.5.0 core security fields (event, cloud, user, source, user_agent, related), resolving the acting identity across every AWS sign-in form (IAM user, SAML/OIDC federation, IAM Identity Center users, and Identity Center role assumption)."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudtrail"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "aws"
+  - "cloudtrail"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # AWS CloudTrail  ->  ECS v9.5.0  (core security fields)
+          #
+          # Input: ONE CloudTrail event record per invocation, as emitted by
+          #   the Monad `cloudtrail` input connector.
+          #
+          # Field mappings:
+          #   .eventTime             -> @timestamp
+          #   .eventName             -> event.action
+          #   .eventID               -> event.id
+          #   .eventSource           -> event.provider
+          #   .awsRegion             -> cloud.region
+          #   .recipientAccountId    -> cloud.account.id
+          #   .sourceIPAddress       -> source.ip / source.address
+          #   .userAgent             -> user_agent.original
+          #   errorCode / ConsoleLogin result -> event.outcome
+          #   the acting identity    -> user.name / user.id
+          #     (+ user.effective.* for the role it acted through)
+          # =================================================================
+
+          # An `ip`-mapped Elasticsearch field rejects the whole document when
+          # handed a hostname (a CloudTrail sourceIPAddress is sometimes an AWS
+          # service name like "cloudtrail.amazonaws.com"), so guard it.
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          # CloudTrail replaces a user name with this sentinel when a console
+          # sign-in fails; it is a redaction marker, not an identity.
+          def real_name($s):
+            if ($s | type) == "string" and $s != "HIDDEN_DUE_TO_SECURITY_REASONS"
+            then $s else null end;
+
+          # requestParameters / responseElements / additionalEventData are not
+          # always JSON objects, so every read of them goes through this guard.
+          def g($o; $k): if ($o | type) == "object" then $o[$k] else null end;
+
+          def sid($o): real_name(g($o; "sourceIdentity"));
+
+          def session_name($p):
+            if ($p | type) == "string" and ($p | test(":"))
+            then ($p | sub("^[^:]*:"; "")) else null end;
+
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+          | ( $r.userIdentity // {} ) as $ui
+          | ( $ui.sessionContext // {} ) as $sc
+          | ( $r.requestParameters ) as $rp
+          | ( $r.responseElements ) as $re
+          | ( $r.additionalEventData ) as $aed
+
+          # ---- outcome ----------------------------------------------------
+          | ( if ($r.errorCode // null) != null then "failure"
+              elif ($r.eventName // "") == "ConsoleLogin"
+                then ( if (g($re; "ConsoleLogin") // "") == "Success"
+                       then "success" else "failure" end )
+              elif (g($aed; "success") // "") == "false" then "failure"
+              else "success" end ) as $outcome
+
+          # ---- event.category --------------------------------------------
+          | ( if (($r.eventName // "") | test("^(ConsoleLogin|SwitchRole|ExitRole|RenewRole|CheckMfa|AssumeRole|AssumeRoot|GetSessionToken|GetFederationToken|AssumeRoleWithSAML|AssumeRoleWithWebIdentity)$"))
+                then ["authentication"]
+              elif (($r.eventSource // "") | test("^(sso|sso-oidc|signin|identitystore)\\."))
+                   and (($r.eventName // "") | test("^(Authenticate|UserAuthentication|CredentialChallenge|CredentialVerification|Federate|CreateToken|CreateTokenWithIAM|StartDeviceAuthorization|Authorize|AuthorizeOAuth2Access|CreateOAuth2Token|GetRoleCredentials|SSOSignIn)$"))
+                then ["authentication"]
+              elif ($r.eventSource // "") | test("^(iam|sso|signin)\\.")
+                then ["iam"]
+              else ["configuration"] end ) as $category
+
+          # ---- event.type (ECS allowed values, valid for the chosen category)
+          | ( if ($r.eventName // "") == "ExitRole" then ["end"]
+              elif $category == ["authentication"] then ["start"]
+              elif ($r.readOnly // false) == true
+                # ECS `iam` has no `access` type; fall back to `info` there.
+                then ( if $category == ["iam"] then ["info"] else ["access"] end )
+              elif (($r.eventName // "") | test("^(Create|Add|Enable|Register|Put|Allocate|Import|Run|Provision|Attach|Associate)"))
+                then ["creation"]
+              elif (($r.eventName // "") | test("^(Delete|Remove|Deregister|Disable|Detach|Disassociate|Terminate|Revoke)"))
+                then ["deletion"]
+              elif (($r.eventName // "") | test("^(Update|Modify|Set|Change|Replace)"))
+                then ["change"]
+              else ["info"] end ) as $type
+
+          # ---- IDENTITY RESOLUTION (most-authoritative first) ------------
+          | ( g($ui.onBehalfOf; "userId") ) as $idc_user_id
+          | ( if $idc_user_id != null then session_name($ui.principalId)
+              else null end ) as $idc_name
+          | ( sid($sc) // sid($rp) // sid($re) ) as $source_identity
+          | ( $source_identity
+              // $idc_name
+              // real_name(g($aed; "UserName"))
+              // real_name($ui.userName) ) as $actor
+          | ( real_name($sc.sessionIssuer.userName) ) as $role_name
+
+          | {
+              ecs: { version: "9.5.0" },
+
+              "@timestamp": $r.eventTime,
+
+              event: {
+                kind: "event",
+                module: "aws",
+                dataset: "aws.cloudtrail",
+                provider: $r.eventSource,
+                action: $r.eventName,
+                id: $r.eventID,
+                category: $category,
+                type: $type,
+                outcome: $outcome
+              },
+
+              cloud: {
+                provider: "aws",
+                region: $r.awsRegion,
+                account: { id: ($r.recipientAccountId // $ui.accountId) }
+              },
+
+              # user.* = initiating identity; user.effective.* = the role whose
+              # privileges were used (the `sudo` model). user.name is bimodal:
+              # the human when identifiable, otherwise the role name (the only
+              # identity CloudTrail supplies for a plain assumed-role session).
+              user: (
+                if $actor != null and $role_name != null then {
+                  id: $idc_user_id,
+                  name: $actor,
+                  effective: {
+                    id: $ui.principalId,
+                    name: $role_name
+                  }
+                } else {
+                  id: ($idc_user_id // $ui.principalId),
+                  name: ($actor // $role_name)
+                } end
+              ),
+
+              source: {
+                address: $r.sourceIPAddress,
+                ip: ( if is_ip($r.sourceIPAddress) then $r.sourceIPAddress else null end )
+              },
+
+              user_agent: { original: $r.userAgent },
+
+              related: {
+                ip: ( if is_ip($r.sourceIPAddress) then [$r.sourceIPAddress] else [] end ),
+                user: ( [ $actor,
+                          $role_name,
+                          $source_identity,
+                          $idc_name,
+                          real_name($ui.userName),
+                          real_name(g($aed; "UserName")),
+                          real_name(g($re; "subject")) ]
+                        | map(select(. != null)) | unique )
+              }
+            }
+          | prune

--- a/ecs/v9.5.0/box/box-events.yaml
+++ b/ecs/v9.5.0/box/box-events.yaml
@@ -1,0 +1,85 @@
+name: "Box Enterprise Events to ECS v9.5.0"
+description: "Maps Box Enterprise Events into Elastic Common Schema (ECS) v9.5.0, populating the event categorization (file), user, source, file, and related field groups."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "box-events"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "box"
+  - "file"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # Box Enterprise Events -> ECS v9.5.0 (nested). One record in, one
+          # nested ECS document out. Single end-of-pipeline walk-based prune.
+          def is_ip($s): ($s | type) == "string"
+            and ($s | test("^([0-9]{1,3}\\.){3}[0-9]{1,3}$") or test(":"));
+
+          def iso8601($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then
+              ((if $ts > 9999999999 then ($ts/1000) else $ts end) | todate)
+            else $ts
+            end;
+
+          . as $r
+          | ($r.created_by) as $cb
+          | ($r.source) as $src
+          | ($r.event_type) as $et
+          # file category -> allowed types: access, change, creation, deletion, info
+          | (if ($et | type) != "string" then "info"
+             elif ($et | test("UPLOAD|CREATE|COPY|ADD|NEW_|RESTORE|UNDELETE")) then "creation"
+             elif ($et | test("DOWNLOAD|PREVIEW|OPEN|VIEW|ACCESS")) then "access"
+             elif ($et | test("DELETE|TRASH|REMOVE|PURGE")) then "deletion"
+             elif ($et | test("EDIT|UPDATE|RENAME|MOVE|CHANGE|LOCK|UNLOCK|SHARE|COLLABORAT")) then "change"
+             else "info" end) as $etype
+          | (if ($et | type) == "string" and ($et | test("FAILED_|ERROR|REJECT|DECLINE|DENIED")) then "failure" else "success" end) as $outcome
+          | {
+              "@timestamp": iso8601($r.created_at),
+              "ecs": { "version": "9.5.0" },
+              "event": {
+                "kind": "event",
+                "category": ["file"],
+                "type": [$etype],
+                "outcome": $outcome,
+                "action": ($et | ascii_downcase? // $et),
+                "id": $r.event_id,
+                "provider": "box",
+                "module": "box",
+                "dataset": "box.events"
+              },
+              "user": ( {
+                "id": ($cb.id | tostring?),
+                "name": ($cb.name // $cb.login),
+                "email": $cb.login,
+                "full_name": $cb.name
+              } ),
+              "source": ( if is_ip($r.ip_address) then { "ip": $r.ip_address } else null end ),
+              "file": ( {
+                "name": ($src.item_name // $src.name),
+                "type": ($src.item_type // $src.type),
+                "size": ($r.additional_details.size),
+                "directory": ($src.parent.name),
+                "owner": ($src.owned_by.name // $src.owned_by.login)
+              } ),
+              "organization": { "name": ($r.additional_details.service_name) },
+              "related": {
+                "ip": ( [ (if is_ip($r.ip_address) then $r.ip_address else null end) ] | map(select(. != null)) | unique ),
+                "user": ( [ $cb.name, $cb.login, $src.owned_by.name, $src.owned_by.login ] | map(select(. != null)) | unique )
+              },
+              "box": {
+                "session_id": $r.session_id,
+                "item_id": ($src.item_id // $src.id),
+                "service_id": ($r.additional_details.service_id)
+              }
+            }
+          # single recursive prune: drop nulls, empty objects, empty arrays
+          | walk( if type == "object" then with_entries(select(.value != null and .value != {} and .value != []))
+                  elif type == "array" then map(select(. != null))
+                  else . end )

--- a/ecs/v9.5.0/crowdstrike/crowdstrike-device-details.yaml
+++ b/ecs/v9.5.0/crowdstrike/crowdstrike-device-details.yaml
@@ -1,0 +1,119 @@
+name: "CrowdStrike Device Details to ECS v9.5.0"
+description: "Normalizes individual CrowdStrike Falcon device details records into Elastic Common Schema (ECS) v9.5.0 asset-inventory fields (event, host, host.os, cloud, agent, observer, related), modeling each record as a host asset snapshot."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-device-details"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "crowdstrike"
+  - "device"
+  - "inventory"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # CrowdStrike Falcon device details -> ECS v9.5.0
+          #
+          # One device record per invocation (Falcon Hosts API
+          # /devices/entities/devices/v2). A device inventory snapshot is an
+          # ASSET state report, so:
+          #   event.kind     = asset
+          #   event.category = [host]
+          #   event.type     = [info]   (host allows access/change/end/info/start)
+          #   event.outcome  = success
+          # =================================================================
+
+          # An ES `ip`-mapped field rejects the whole document if handed a
+          # non-IP string, so guard every ip field.
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$")
+                 or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          # Recursively drop nulls / empty objects / empty arrays (ES rejects
+          # nulls; the doc is deeply nested). The one permitted recursive pass.
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+          | ( [ $r.local_ip, $r.external_ip, $r.connection_ip, $r.default_gateway_ip ]
+              | map(select(is_ip(.))) | unique ) as $ips
+          | ( [ $r.mac_address, $r.connection_mac_address ]
+              | map(select(. != null)) | unique ) as $macs
+          | {
+              "@timestamp": $r.agent_local_time,
+
+              ecs: { version: "9.5.0" },
+
+              event: {
+                kind: "asset",
+                module: "crowdstrike",
+                dataset: "crowdstrike.device",
+                category: ["host"],
+                type: ["info"],
+                outcome: "success",
+                created: $r.modified_timestamp
+              },
+
+              host: {
+                id: $r.device_id,
+                name: $r.hostname,
+                hostname: $r.hostname,
+                domain: $r.machine_domain,
+                type: $r.product_type_desc,
+                ip: ( if ($ips | length) > 0 then $ips else null end ),
+                mac: ( if ($macs | length) > 0 then $macs else null end ),
+                architecture: ( if $r.platform_name == "Windows" then "x86_64" else null end ),
+                os: {
+                  name: $r.os_version,
+                  version: $r.os_version,
+                  full: $r.os_version,
+                  kernel: $r.kernel_version,
+                  type: ( ($r.platform_name // "") | ascii_downcase
+                          | if . == "mac" then "macos" else . end ),
+                  platform: ( ($r.platform_name // null) | if . == null then null else ascii_downcase end ),
+                  family: $r.platform_name
+                }
+              },
+
+              cloud: {
+                provider: ( ($r.service_provider // "") | ascii_downcase
+                            | if startswith("aws") then "aws"
+                              elif startswith("azure") then "azure"
+                              elif startswith("gcp") or startswith("google") then "gcp"
+                              else null end ),
+                account: { id: $r.service_provider_account_id },
+                instance: { id: $r.instance_id }
+              },
+
+              agent: {
+                type: "crowdstrike-falcon",
+                id: $r.device_id,
+                name: $r.hostname,
+                version: $r.agent_version
+              },
+
+              observer: {
+                vendor: "CrowdStrike",
+                product: "Falcon",
+                type: "edr"
+              },
+
+              related: {
+                ip: $ips,
+                hosts: ( [ $r.hostname ] | map(select(. != null)) | unique )
+              }
+            }
+          | prune

--- a/ecs/v9.5.0/crowdstrike/crowdstrike-event-stream.yaml
+++ b/ecs/v9.5.0/crowdstrike/crowdstrike-event-stream.yaml
@@ -1,0 +1,124 @@
+name: "CrowdStrike Event Stream Detections to ECS v9.5.0"
+description: "Transforms CrowdStrike Falcon Event Stream DetectionSummaryEvent records into a nested Elastic Common Schema (ECS) v9.5.0 document, populating event categorization plus host.*, user.*, process.*, file.*, threat.*, and related.* field sets."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-event-stream"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "crowdstrike"
+  - "detection"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # CrowdStrike Falcon Event Stream (DetectionSummaryEvent) -> ECS v9.5.0
+          # One nested ECS document per record. event.kind=alert; category
+          # [malware, intrusion_detection] with type [info] (the only type
+          # legal for the malware category).
+          # ---------------------------------------------------------------
+          def is_ip($s):
+            ($s | type) == "string"
+            and ( ($s | test("^[0-9]{1,3}(\\.[0-9]{1,3}){3}$"))
+                  or ($s | test(":")) );
+
+          def to_iso_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number"
+              then ((if $ts > 1000000000000 then ($ts / 1000) else $ts end) | todateiso8601)
+            else null end;
+
+          . as $r
+          | ($r.event // {}) as $e
+          | ($r.metadata // {}) as $m
+          | ($e.PatternDispositionValue // 0) as $disp
+          | {
+              "@timestamp": to_iso_ms($m.eventCreationTime),
+              ecs: { version: "9.5.0" },
+
+              event: {
+                kind: "alert",
+                category: ["malware", "intrusion_detection"],
+                type: ["info"],
+                outcome: (if $disp > 0 then "success" else "unknown" end),
+                provider: "CrowdStrike Falcon",
+                module: "crowdstrike",
+                dataset: "crowdstrike.event_stream",
+                action: $e.DetectName,
+                id: $e.DetectId,
+                reference: $e.FalconHostLink,
+                severity: $e.Severity,
+                original: ($r | tojson)
+              },
+
+              rule: {
+                name: $e.DetectName,
+                description: $e.DetectDescription
+              },
+
+              message: $e.DetectDescription,
+
+              host: {
+                name: $e.ComputerName,
+                hostname: $e.ComputerName,
+                domain: $e.MachineDomain,
+                id: $e.SensorId,
+                ip: (if is_ip($e.LocalIP) then [$e.LocalIP] else null end),
+                mac: (if ($e.MACAddress // "") != "" then [$e.MACAddress] else null end)
+              },
+
+              user: {
+                name: $e.UserName
+              },
+
+              process: {
+                pid: $e.ProcessId,
+                name: $e.FileName,
+                executable: $e.FilePath,
+                command_line: $e.CommandLine,
+                hash: {
+                  sha256: $e.SHA256String,
+                  md5: $e.MD5String
+                },
+                parent: {
+                  pid: $e.ParentProcessId,
+                  command_line: $e.ParentCommandLine
+                }
+              },
+
+              file: {
+                name: $e.FileName,
+                path: $e.FilePath,
+                hash: {
+                  sha256: $e.SHA256String,
+                  md5: $e.MD5String
+                }
+              },
+
+              threat: {
+                tactic: { name: (if ($e.Tactic // "") != "" then [$e.Tactic] else null end) },
+                technique: { name: (if ($e.Technique // "") != "" then [$e.Technique] else null end) }
+              },
+
+              related: {
+                ip: ( [ (if is_ip($e.LocalIP) then $e.LocalIP else null end) ]
+                      | map(select(. != null)) | unique ),
+                user: ( [ $e.UserName ] | map(select(. != null and . != "")) | unique ),
+                hosts: ( [ $e.ComputerName ] | map(select(. != null and . != "")) | unique ),
+                hash: ( [ $e.SHA256String, $e.MD5String ]
+                        | map(select(. != null and . != "")) | unique )
+              }
+            }
+          | walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != "" and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null and . != "" and . != {} and . != []))
+              else .
+              end
+            )

--- a/ecs/v9.5.0/crowdstrike/crowdstrike-falcon-data-replicator.yaml
+++ b/ecs/v9.5.0/crowdstrike/crowdstrike-falcon-data-replicator.yaml
@@ -1,0 +1,110 @@
+name: "CrowdStrike Falcon Data Replicator to ECS v9.5.0"
+description: "Transforms a CrowdStrike Falcon Data Replicator (FDR) ProcessRollup2 endpoint telemetry record into Elastic Common Schema (ECS) v9.5.0, covering the event, host, process, user, agent, observer, and related field sets."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-falcon-data-replicator"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "crowdstrike"
+  - "process"
+  - "falcon-data-replicator"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # ECS v9.5.0 — CrowdStrike Falcon Data Replicator ProcessRollup2
+          # One raw FDR endpoint record -> one nested ECS document.
+          # ---------------------------------------------------------------
+
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^([0-9]{1,3}\\.){3}[0-9]{1,3}$")
+                 or ($s | test(":")));
+
+          def basename($p):
+            if $p == null or $p == "" then null
+            else ($p | gsub("\\\\"; "/") | split("/") | last)
+            end;
+
+          # FDR .timestamp is epoch milliseconds (string) -> ISO-8601 UTC.
+          def to_iso_ms($ts):
+            if $ts == null or $ts == ""
+            then null
+            else (($ts | tonumber) / 1000 | todateiso8601)
+            end;
+
+          . as $r
+          | ($r.aip) as $aip
+          | {
+              "@timestamp": to_iso_ms($r.timestamp),
+              ecs: { version: "9.5.0" },
+              event: {
+                kind: "event",
+                category: ["process"],
+                type: ["start"],
+                outcome: "unknown",
+                action: $r.event_simpleName,
+                module: "crowdstrike",
+                dataset: "crowdstrike.fdr",
+                provider: "falcon-data-replicator"
+              },
+              agent: {
+                id: $r.aid,
+                type: "crowdstrike-falcon"
+              },
+              observer: {
+                vendor: "CrowdStrike",
+                product: "Falcon Data Replicator"
+              },
+              organization: {
+                id: $r.cid
+              },
+              host: {
+                name: $r.ComputerName,
+                hostname: $r.ComputerName,
+                id: $r.aid,
+                ip: (if is_ip($aip) then [$aip] else null end),
+                os: {
+                  type: "windows",
+                  family: "windows",
+                  name: "Windows"
+                }
+              },
+              process: {
+                pid: (if $r.RawProcessId != null then ($r.RawProcessId | tonumber) else null end),
+                name: basename($r.ImageFileName),
+                executable: ($r.ImageFileName | if . == null then null else gsub("\\\\"; "/") end),
+                command_line: $r.CommandLine,
+                start: to_iso_ms(($r.ProcessStartTime // "" | if . == "" then "" else ((tonumber * 1000) | floor | tostring) end)),
+                hash: {
+                  sha256: $r.SHA256HashData,
+                  md5: $r.MD5HashData
+                },
+                parent: {
+                  name: $r.ParentBaseFileName
+                }
+              },
+              user: {
+                name: $r.UserName,
+                id: $r.UserSid
+              },
+              related: {
+                user: ([$r.UserName] | map(select(. != null and . != "")) | unique),
+                hosts: ([$r.ComputerName] | map(select(. != null and . != "")) | unique),
+                hash: ([$r.SHA256HashData, $r.MD5HashData] | map(select(. != null and . != "")) | unique),
+                ip: ([$aip] | map(select(is_ip(.))) | unique)
+              }
+            }
+          | walk(
+              if type == "object"
+              then with_entries(select(.value != null and .value != "" and .value != [] and .value != {}))
+              elif type == "array" then map(select(. != null and . != ""))
+              else .
+              end
+            )

--- a/ecs/v9.5.0/crowdstrike/crowdstrike-vulnerabilities.yaml
+++ b/ecs/v9.5.0/crowdstrike/crowdstrike-vulnerabilities.yaml
@@ -1,0 +1,115 @@
+name: "CrowdStrike Vulnerabilities to ECS v9.5.0"
+description: "Normalizes individual CrowdStrike Spotlight vulnerability findings into the Elastic Common Schema (ECS) v9.5.0 (event categorization, vulnerability.*, host.*, os.*, cloud.*, related.*), emitting event.kind=alert in the vulnerability category."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-vulnerabilities"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "crowdstrike"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # CrowdStrike Spotlight vulnerabilities -> ECS v9.5.0
+          #
+          # Input: ONE Spotlight combined-vulnerability record per invocation,
+          #   as emitted by the `crowdstrike-vulnerabilities` input connector.
+          #
+          # A vulnerability finding is a security assessment, not an activity,
+          # so it maps to event.kind=alert + event.category=[vulnerability]
+          # (whose only allowed event.type is `info`). event.outcome is
+          # `unknown` — a finding has no success/failure outcome.
+          # =================================================================
+
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          # Recursively drop nulls and empty objects/arrays so the emitted
+          # document stays compact (ES rejects null values). Single permitted
+          # recursive pass.
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+          | ( $r.cve // {} ) as $cve
+          | ( $r.host_info // {} ) as $h
+          | ( $r.remediation.entities // [] ) as $rem
+
+          # ECS vulnerability.severity is a normalized lowercase keyword.
+          | ( ($cve.severity // "") | ascii_downcase ) as $sev
+
+          | {
+              ecs: { version: "9.5.0" },
+
+              "@timestamp": $r.created_timestamp,
+
+              event: {
+                kind: "alert",
+                module: "crowdstrike",
+                dataset: "crowdstrike.vulnerability",
+                provider: "CrowdStrike Falcon Spotlight",
+                id: $r.id,
+                category: ["vulnerability"],
+                type: ["info"],
+                outcome: "unknown",
+                severity: ($cve.base_score // null),
+                created: $r.created_timestamp
+              },
+
+              vulnerability: {
+                id: $r.vulnerability_id,
+                enumeration: "CVE",
+                description: $cve.description,
+                reference: ($cve.references // [])[0],
+                severity: ( if $sev == "" then null else $sev end ),
+                classification: "CVSS",
+                scanner: { vendor: "CrowdStrike" },
+                score: {
+                  base: ($cve.base_score // null),
+                  version: (if $cve.vector then ($cve.vector | ltrimstr("CVSS:") | split("/")[0]) else null end)
+                },
+                status: $r.status
+              },
+
+              host: {
+                name: $h.hostname,
+                hostname: $h.hostname,
+                id: $r.aid,
+                domain: $h.machine_domain,
+                ip: ( if is_ip($h.local_ip) then [$h.local_ip] else [] end ),
+                os: {
+                  platform: ( if $h.platform then ($h.platform | ascii_downcase) else null end ),
+                  name: $h.platform,
+                  version: $h.os_version,
+                  full: (($h.platform // "") + " " + ($h.os_version // "") | gsub("^\\s+|\\s+$"; ""))
+                }
+              },
+
+              cloud: (
+                if $h.service_provider then {
+                  provider: $h.service_provider,
+                  account: { id: $h.service_provider_account_id },
+                  instance: { id: $h.instance_id }
+                } else null end
+              ),
+
+              related: {
+                ip: ( if is_ip($h.local_ip) then [$h.local_ip] else [] end ),
+                hosts: ( [ $h.hostname ] | map(select(. != null)) | unique )
+              }
+            }
+          | prune

--- a/ecs/v9.5.0/duo-security/duo-security-auth-logs.yaml
+++ b/ecs/v9.5.0/duo-security/duo-security-auth-logs.yaml
@@ -1,0 +1,100 @@
+name: "Duo Security Authentication Logs to ECS v9.5.0"
+description: "Maps Cisco Duo Security authentication log records into Elastic Common Schema (ECS) v9.5.0, covering event categorization, user, source, host/os, and related.* field groups."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "duo-security-auth-logs"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "duo-security"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # ECS v9.5.0 — Duo Security authentication log -> nested ECS doc.
+          # One record per invocation. Single construction pass, one prune.
+          # ---------------------------------------------------------------
+          def is_ip($s): ($s | type) == "string"
+            and ($s | test("^([0-9]{1,3}\\.){3}[0-9]{1,3}$") or test(":"));
+          def to_iso($r):
+            if ($r.isotimestamp // null) != null then ($r.isotimestamp | sub("\\+00:00$"; "Z"))
+            elif ($r.timestamp // null) != null then ($r.timestamp | todateiso8601)
+            else null end;
+
+          . as $r
+          | ($r.result // "" | ascii_downcase) as $result
+          | (if $result == "success" then "success"
+             elif $result == "" then "unknown"
+             else "failure" end) as $outcome
+          | {
+              "@timestamp": to_iso($r),
+              "ecs": { "version": "9.5.0" },
+              "event": {
+                "kind": "event",
+                "category": ["authentication"],
+                "type": (if $outcome == "success" then ["start", "info"] else ["info"] end),
+                "outcome": $outcome,
+                "action": ($r.event_type // "authentication"),
+                "id": $r.txid,
+                "provider": "duo",
+                "module": "duo_security",
+                "dataset": "duo_security.auth",
+                "reason": ($r.reason // null),
+                "original": ($r | tostring)
+              },
+              "user": ({
+                "name": ($r.user.name // $r.email),
+                "id": ($r.user.key // null),
+                "email": ($r.email // null),
+                "domain": (($r.email // "") | (if index("@") then split("@")[1] else null end)),
+                "group": (($r.user.groups // []) | map(select(. != null and . != "")) | if length > 0 then { "name": . } else null end)
+              } | with_entries(select(.value != null and .value != ""))),
+              "source": ({
+                "ip": (if is_ip($r.access_device.ip // null) then $r.access_device.ip else null end),
+                "address": ($r.access_device.ip // null),
+                "geo": (if ($r.access_device.location // null) != null
+                        then { "city_name": ($r.access_device.location.city // null),
+                               "region_name": ($r.access_device.location.state // null),
+                               "country_name": ($r.access_device.location.country // null) }
+                             | with_entries(select(.value != null))
+                        else null end)
+              } | with_entries(select(.value != null and .value != {}))),
+              "host": ({
+                "hostname": ($r.access_device.hostname // null),
+                "os": (if ($r.access_device.os // null) != null
+                       then { "name": ($r.access_device.os // null),
+                              "version": ($r.access_device.os_version // null),
+                              "full": ((($r.access_device.os // "") + " " + ($r.access_device.os_version // "")) | sub("^ +| +$"; "")) }
+                            | with_entries(select(.value != null and .value != ""))
+                       else null end)
+              } | with_entries(select(.value != null and .value != {}))),
+              "user_agent": ({
+                "name": ($r.access_device.browser // null),
+                "version": ($r.access_device.browser_version // null)
+              } | with_entries(select(.value != null))),
+              "service": ({
+                "name": ($r.application.name // null),
+                "id": ($r.application.key // null)
+              } | with_entries(select(.value != null))),
+              "observer": {
+                "vendor": "Cisco",
+                "product": "Duo Security",
+                "type": "authentication"
+              },
+              "related": ({
+                "user": ([$r.user.name, $r.email] | map(select(. != null and . != "")) | unique),
+                "ip": ([$r.access_device.ip, $r.auth_device.ip] | map(select(is_ip(.))) | unique)
+              } | with_entries(select(.value != null and (.value | length) > 0))),
+              "labels": ({
+                "duo_factor": ($r.factor // null),
+                "duo_result": ($r.result // null),
+                "trusted_endpoint_status": ($r.trusted_endpoint_status // null)
+              } | with_entries(select(.value != null and .value != "")))
+            }
+          | walk(if type == "object" then with_entries(select(.value != null and .value != "" and .value != {} and .value != [])) else . end)

--- a/ecs/v9.5.0/github/github-audit-logs.yaml
+++ b/ecs/v9.5.0/github/github-audit-logs.yaml
@@ -1,0 +1,97 @@
+name: "GitHub Audit Logs to ECS v9.5.0"
+description: "Maps GitHub (Enterprise/Organization) audit log records into Elastic Common Schema (ECS) v9.5.0, populating event categorization, user, source, organization, and related field sets."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "github-audit-logs"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "github"
+  - "audit-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # GitHub audit logs -> ECS v9.5.0 (nested document).
+          # event.kind=event; category/type derived from operation_type;
+          # one jq pass, bind-once, is_ip guard, related.* union, single
+          # end-of-pipeline walk prune.
+          # ---------------------------------------------------------------
+          . as $r
+          | def is_ip($s): ($s | type) == "string"
+              and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$|:"));
+
+          # operation_type -> valid ECS (category, type) pairing.
+          ( if   $r.operation_type == "create"         then { c: ["iam"],           t: ["creation","user"] }
+              elif $r.operation_type == "modify"         then { c: ["iam"],           t: ["change"] }
+              elif $r.operation_type == "remove"         then { c: ["iam"],           t: ["deletion"] }
+              elif $r.operation_type == "access"         then { c: ["configuration"], t: ["access"] }
+              elif $r.operation_type == "authentication" then { c: ["authentication"],t: ["info"] }
+              elif $r.operation_type == "transfer"       then { c: ["iam"],           t: ["change"] }
+              else { c: ["configuration"], t: ["info"] } end ) as $cat
+
+          | ($r.created_at // $r["@timestamp"]) as $ts
+          | (if ($ts | type) == "number"
+             then ($ts | (. / 1000) | strftime("%Y-%m-%dT%H:%M:%S.000Z"))
+             else $ts end) as $iso
+
+          | {
+              "@timestamp": $iso,
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "event",
+                "category": $cat.c,
+                "type": $cat.t,
+                "outcome": "success",
+                "action": $r.action,
+                "id": $r._document_id,
+                "provider": "github-audit-log",
+                "module": "github"
+              },
+
+              "user": {
+                "name": $r.actor,
+                "id": (if $r.actor_id != null then ($r.actor_id | tostring) else null end),
+                "target": {
+                  "name": $r.user,
+                  "id": (if $r.user_id != null then ($r.user_id | tostring) else null end)
+                }
+              },
+
+              "source": {
+                "ip": (if is_ip($r.actor_ip) then $r.actor_ip else null end),
+                "geo": { "country_iso_code": $r.actor_location.country_code }
+              },
+
+              "user_agent": { "original": $r.user_agent },
+
+              "organization": {
+                "name": $r.org,
+                "id": (if $r.org_id != null then ($r.org_id | tostring) else null end)
+              },
+
+              "group": { "name": $r.team },
+
+              "related": {
+                "user": ([$r.actor, $r.user] | map(select(. != null)) | unique),
+                "ip": ([ (if is_ip($r.actor_ip) then $r.actor_ip else null end) ]
+                       | map(select(. != null)) | unique)
+              },
+
+              "github": {
+                "org": $r.org,
+                "repository": ($r.repo // $r.repository),
+                "team": $r.team,
+                "business": $r.business,
+                "operation_type": $r.operation_type
+              }
+            }
+
+          | walk( if type == "object" then with_entries(select(.value != null and .value != "" and .value != {} and .value != []))
+                  elif type == "array" then map(select(. != null)) else . end )

--- a/ecs/v9.5.0/github/github-dependabot-alerts.yaml
+++ b/ecs/v9.5.0/github/github-dependabot-alerts.yaml
@@ -1,0 +1,106 @@
+name: "GitHub Dependabot Alerts to ECS v9.5.0"
+description: "Normalizes a GitHub Dependabot vulnerability alert record into the Elastic Common Schema (ECS) v9.5.0 (event categorization, vulnerability, package, organization, url, related), mapping the advisory CVE/GHSA identifiers, CVSS score, affected package, and repository context."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "github-dependabot-alerts"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "github"
+  - "dependabot"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # GitHub Dependabot Alert  ->  ECS v9.5.0
+          #   event.kind: alert; event.category: [vulnerability];
+          #   event.type: [info] (the only type ECS pairs with vulnerability)
+          #
+          #   .updated_at/.created_at   -> @timestamp / event.created
+          #   security_advisory.cve_id  -> vulnerability.id, related.hosts n/a
+          #   security_advisory.ghsa_id -> vulnerability.report_id
+          #   cwes[].cwe_id             -> vulnerability.enumeration/classification
+          #   cvss.score/version        -> vulnerability.score.base/version
+          #   dependency.package        -> package.name/type + vulnerability
+          #   repository.owner.login    -> organization.name
+          #   html_url                  -> url.full / event.reference
+          # =================================================================
+          . as $r
+          | ($r.security_advisory // {}) as $adv
+          | ($r.security_vulnerability // {}) as $sv
+          | ($r.dependency // {}) as $dep
+          | (($dep.package // $sv.package // $adv.vulnerabilities[0].package) // {}) as $pkg
+          | ($adv.severity // $sv.severity // null) as $sev
+          | ($adv.cve_id // $adv.ghsa_id) as $vid
+
+          | (if $r.state == "fixed" then "success"
+             elif ($r.state == "dismissed" or $r.state == "auto_dismissed") then "unknown"
+             else "unknown" end) as $outcome
+
+          | {
+              "@timestamp": ($r.updated_at // $r.created_at),
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "alert",
+                "category": ["vulnerability"],
+                "type": ["info"],
+                "outcome": $outcome,
+                "id": ($r.number | tostring),
+                "provider": "dependabot",
+                "module": "github",
+                "dataset": "github.dependabot_alerts",
+                "created": $r.created_at,
+                "url": $r.html_url,
+                "reference": ($adv.references[0].url // null),
+                "severity": ({ "low": 21, "medium": 47, "high": 73, "critical": 99 }[$sev] // null)
+              },
+
+              "vulnerability": {
+                "id": $vid,
+                "report_id": $adv.ghsa_id,
+                "description": ($adv.summary // $adv.description),
+                "severity": (if $sev != null then ($sev | (.[0:1] | ascii_upcase) + .[1:]) else null end),
+                "reference": ($adv.references[0].url // $r.html_url),
+                "scanner": { "vendor": "GitHub Dependabot" },
+                "status": $r.state,
+                "enumeration": (if $adv.cve_id then "CVE" else "GHSA" end),
+                "classification": ($adv.cwes[0].cwe_id // null),
+                "category": [ ($pkg.ecosystem // "dependency") ],
+                "score": ( if ($adv.cvss.score // null) != null then {
+                    "base": $adv.cvss.score,
+                    "version": ( ($adv.cvss.vector_string | capture("^CVSS:(?<v>[0-9.]+)").v) // null )
+                } else null end )
+              },
+
+              "package": {
+                "name": $pkg.name,
+                "type": $pkg.ecosystem,
+                "path": $dep.manifest_path,
+                "reference": $r.html_url
+              },
+
+              "organization": {
+                "name": ($r.repository.owner.login // null),
+                "id": (if ($r.repository.owner.id // null) != null then ($r.repository.owner.id | tostring) else null end)
+              },
+
+              "url": {
+                "full": $r.html_url,
+                "domain": "github.com"
+              },
+
+              "message": ($adv.summary // ("Dependabot alert " + ($r.number | tostring))),
+              "tags": [ ($r.repository.full_name // empty) ],
+
+              "related": {
+                "hosts": [ ($r.repository.full_name // empty) ]
+              }
+            }
+          | walk( if type == "object" then with_entries(select(.value != null and .value != "" and .value != [] and .value != {})) else . end )

--- a/ecs/v9.5.0/google/google-cloud-logs.yaml
+++ b/ecs/v9.5.0/google/google-cloud-logs.yaml
@@ -1,0 +1,93 @@
+name: "Google Cloud Audit Logs to ECS v9.5.0"
+description: "Transforms Google Cloud (Cloud Audit) Logs into Elastic Common Schema (ECS) v9.5.0, populating the event, cloud, user, source, user_agent, service, and related field sets."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "google-cloud-logs"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "google"
+  - "gcp"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Google Cloud Audit Logs -> ECS v9.5.0 (nested). One record/call.
+          # event.category: api  (cloud management API activity)
+          # ---------------------------------------------------------------
+          def is_ip($s): ($s|type)=="string" and ($s|test("^[0-9]{1,3}(\\.[0-9]{1,3}){3}$") or ($s|test(":")));
+
+          . as $r
+          | ($r.protoPayload // {}) as $pp
+          | ($pp.requestMetadata // {}) as $rm
+          | ($pp.authenticationInfo // {}) as $ai
+          | (($r.resource // {}).labels // {}) as $lbl
+          | ($pp.methodName // "") as $mn
+          | ($mn | ascii_downcase) as $mnl
+          | (if   ($mnl | test("insert|create")) then "creation"
+             elif ($mnl | test("delete|remove")) then "deletion"
+             elif ($mnl | test("update|patch|set|write")) then "change"
+             elif ($mnl | test("get|list|read|aggregatedlist|search|batchget")) then "access"
+             else "info" end) as $etype
+          | (($pp.status // {}).code // 0) as $status_code
+          | {
+              "@timestamp": $r.timestamp,
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "event",
+                "category": ["api"],
+                "type": [$etype],
+                "outcome": (if $status_code == 0 then "success" else "failure" end),
+                "action": $mn,
+                "id": $r.insertId,
+                "provider": $pp.serviceName,
+                "created": $r.receiveTimestamp,
+                "code": ($status_code | tostring)
+              },
+
+              "cloud": {
+                "provider": "gcp",
+                "project": { "id": $lbl.project_id },
+                "availability_zone": $lbl.zone,
+                "service": { "name": $pp.serviceName },
+                "instance": { "id": $lbl.instance_id }
+              },
+
+              "user": {
+                "name": $ai.principalEmail,
+                "email": $ai.principalEmail
+              },
+
+              "source": {
+                "ip": (if is_ip($rm.callerIp) then $rm.callerIp else null end),
+                "address": $rm.callerIp
+              },
+
+              "user_agent": {
+                "original": $rm.callerSuppliedUserAgent
+              },
+
+              "service": {
+                "name": $pp.serviceName
+              },
+
+              "log": {
+                "level": ($r.severity | ascii_downcase?),
+                "logger": $r.logName
+              },
+
+              "message": ($mn + " on " + ($pp.resourceName // "")),
+
+              "related": {
+                "ip": ([ (if is_ip($rm.callerIp) then $rm.callerIp else empty end) ] | unique),
+                "user": ([ $ai.principalEmail ] | map(select(. != null)) | unique)
+              }
+            }
+          | walk(if type == "object" then with_entries(select(.value != null and .value != "" and .value != [] and .value != {})) else . end)

--- a/ecs/v9.5.0/google/google-workspace-login-activity.yaml
+++ b/ecs/v9.5.0/google/google-workspace-login-activity.yaml
@@ -1,0 +1,105 @@
+name: "Google Workspace Login Activity to ECS v9.5.0"
+description: "Normalizes Google Workspace (Admin SDK Reports API) login activity records into Elastic Common Schema (ECS) v9.5.0 core security fields (event, user, source, cloud, related), categorized as authentication."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "google-workspace-login-activity"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "google"
+  - "login"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # Google Workspace login activity -> ECS v9.5.0 (core fields)
+          # Input: ONE Reports API login activity record per invocation.
+          #   .id.time            -> @timestamp
+          #   .events[0].name     -> event.action / outcome / type
+          #   .id.uniqueQualifier -> event.id
+          #   .actor.email        -> user.email / user.name
+          #   .actor.profileId    -> user.id
+          #   .ipAddress          -> source.ip / source.address
+          # =================================================================
+
+          # An ES `ip` field rejects a non-IP document, so guard before use.
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+          | ($r.events[0] // {}) as $ev
+          | ($ev.parameters // []) as $params
+          | ($ev.name // "") as $ename
+          | def param($n): ($params | map(select(.name == $n)) | first);
+            def pstr($n): (param($n) | if . == null then null
+                           else (.value // ((.multiValue // []) | join(","))) end);
+            ($r.actor.email) as $email
+          | ($r.ipAddress) as $ip
+
+          # event.outcome (closed enum)
+          | ( if $ename == "login_success" then "success"
+              elif ($ename | startswith("login_failure") or startswith("suspicious")) then "failure"
+              else "unknown" end ) as $outcome
+
+          # event.type (must be legal for category=authentication: start/end/info)
+          | ( if ($ename | startswith("logout")) then ["end"]
+              elif ($ename | startswith("login_success") or startswith("login_failure") or startswith("suspicious")) then ["start"]
+              else ["info"] end ) as $type
+
+          | {
+              ecs: { version: "9.5.0" },
+
+              "@timestamp": $r.id.time,
+
+              event: {
+                kind: "event",
+                module: "google_workspace",
+                dataset: "google_workspace.login",
+                provider: ($r.id.applicationName // "login"),
+                action: $ename,
+                id: ($r.id.uniqueQualifier | tostring),
+                category: ["authentication"],
+                type: $type,
+                outcome: $outcome
+              },
+
+              user: {
+                id: ($r.actor.profileId // null),
+                name: $email,
+                email: $email,
+                domain: ($r.ownerDomain // null)
+              },
+
+              source: {
+                address: $ip,
+                ip: ( if is_ip($ip) then $ip else null end )
+              },
+
+              cloud: {
+                provider: "google_workspace",
+                account: { id: ($r.id.customerId // null) }
+              },
+
+              related: {
+                ip: ( if is_ip($ip) then [$ip] else [] end ),
+                user: ( [ $email, ($r.actor.profileId), (pstr("affected_email_address")) ]
+                        | map(select(. != null)) | unique )
+              }
+            }
+          | prune

--- a/ecs/v9.5.0/jumpcloud/jumpcloud-events.yaml
+++ b/ecs/v9.5.0/jumpcloud/jumpcloud-events.yaml
@@ -1,0 +1,94 @@
+name: "JumpCloud Directory Insights Events to ECS v9.5.0"
+description: "Maps JumpCloud Directory Insights event records into Elastic Common Schema (ECS) v9.5.0, covering event categorization, user, source (ip + geo), user_agent, cloud, and related.* field groups."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "jumpcloud-events"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "jumpcloud"
+  - "events"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # JumpCloud Directory Insights -> ECS v9.5.0 (nested).
+          # One record per invocation; single construction pass; single
+          # end-of-pipeline walk prune (drops null/{}/[]).
+          # ---------------------------------------------------------------
+          def is_ip($s): ($s | type) == "string"
+            and ($s | test("^([0-9]{1,3}\\.){3}[0-9]{1,3}$|:"));
+
+          . as $r
+          | ($r.initiated_by // {}) as $ib
+          | ($r.geoip // {}) as $geo
+          | ($r.useragent // {}) as $ua
+          | (($r.event_type // "") | ascii_downcase) as $et
+          | ($r.username // $ib.username) as $uname
+
+          | {
+              "@timestamp": $r.timestamp,
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "event",
+                "category": [ "authentication" ],
+                "type": (if ($et | test("logout|logoff")) then [ "end" ] else [ "start" ] end),
+                "outcome": (if $r.success == true then "success"
+                            elif $r.success == false then "failure" else "unknown" end),
+                "action": $r.event_type,
+                "id": $r.id,
+                "provider": "jumpcloud",
+                "module": "jumpcloud",
+                "dataset": "jumpcloud.events",
+                "original": ($r | tojson)
+              },
+
+              "message": $r.message,
+
+              "user": {
+                "name": $uname,
+                "id": (if $ib.type == "user" then $ib.id else null end)
+              },
+
+              "source": {
+                "ip": (if is_ip($r.client_ip) then $r.client_ip else null end),
+                "geo": {
+                  "country_iso_code": $geo.country_code,
+                  "region_iso_code": $geo.region_code,
+                  "region_name": $geo.region_name,
+                  "timezone": $geo.timezone,
+                  "location": (if ($geo.longitude != null and $geo.latitude != null)
+                               then "\($geo.latitude),\($geo.longitude)" else null end)
+                }
+              },
+
+              "user_agent": {
+                "name": $ua.name,
+                "version": $ua.version,
+                "os": {
+                  "name": $ua.os,
+                  "version": $ua.os_version
+                }
+              },
+
+              "cloud": {
+                "provider": "jumpcloud",
+                "account": { "id": $r.organization }
+              },
+
+              "related": {
+                "user": ( [ $uname, $ib.username ] | map(select(. != null)) | unique ),
+                "ip":   ( [ (if is_ip($r.client_ip) then $r.client_ip else null end) ]
+                          | map(select(. != null)) | unique )
+              }
+            }
+          | walk(if type == "object" then with_entries(select(
+                   .value != null and .value != "" and .value != [] and .value != {}))
+                 elif type == "array" then map(select(. != null))
+                 else . end)

--- a/ecs/v9.5.0/microsoft/microsoft-azure-activity-logs.yaml
+++ b/ecs/v9.5.0/microsoft/microsoft-azure-activity-logs.yaml
@@ -1,0 +1,119 @@
+name: "Microsoft Azure Activity Logs to ECS v9.5.0"
+description: "Normalizes individual Microsoft Azure Activity Log records (control-plane management operations) into the Elastic Common Schema (ECS) v9.5.0 core security fields (event, cloud, user, source, related), deriving event categorization from the Azure operationName verb and resultType."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "microsoft-azure-activity-logs"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "microsoft"
+  - "azure"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # Microsoft Azure Activity Log  ->  ECS v9.5.0  (CORE fields)
+          #
+          # Input: ONE Azure Activity Log record per invocation (Azure Monitor
+          #   resource-log schema, as emitted by the microsoft-azure-activity-logs
+          #   input connector).
+          #
+          #   .time / .eventTimestamp   -> @timestamp
+          #   .operationName            -> event.action  (+ verb -> event.type)
+          #   .eventDataId              -> event.id
+          #   .resultType / .status     -> event.outcome
+          #   .callerIpAddress          -> source.ip / source.address
+          #   .caller                   -> user.name
+          #   .subscriptionId           -> cloud.account.id
+          #   .location                 -> cloud.region
+          # =================================================================
+
+          # A callerIpAddress can be absent or a non-IP token; an ES ip-mapped
+          # field rejects a document handed a hostname, so guard it.
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          # operationName / resultType may arrive as {value, localizedValue}.
+          def strv($f):
+            if ($f | type) == "object" then ($f.value // $f.localizedValue)
+            else $f end;
+
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+          | ( $r.identity.claims // {} ) as $claims
+          | ( strv($r.operationName) // "" ) as $op
+          | ( $op | ascii_downcase ) as $opl
+          | ( strv($r.resultType) // $r.status // "" ) as $result
+          | ( $r.caller
+              // $claims["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
+              // $claims["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"] ) as $caller
+          | ( $claims["http://schemas.microsoft.com/identity/claims/objectidentifier"] ) as $caller_uid
+          | ( $r.callerIpAddress // $claims.ipaddr ) as $caller_ip
+
+          # ---- outcome ----------------------------------------------------
+          | ( if ($result | ascii_downcase | startswith("succ")) then "success"
+              elif ($result | ascii_downcase | startswith("fail")) then "failure"
+              else "unknown" end ) as $outcome
+
+          # ---- event.type from the Azure operation verb -------------------
+          # Azure control-plane ops are configuration changes; the trailing
+          # verb selects the ECS type (all legal for category=configuration).
+          | ( if ($opl | endswith("/write")) then ["change"]
+              elif ($opl | endswith("/read")) then ["access"]
+              elif ($opl | endswith("/delete")) then ["deletion"]
+              else ["info"] end ) as $type
+
+          | {
+              ecs: { version: "9.5.0" },
+
+              "@timestamp": ($r.time // $r.eventTimestamp),
+
+              event: {
+                kind: "event",
+                module: "azure",
+                dataset: "azure.activitylogs",
+                provider: ($op | split("/")[0]),
+                action: $op,
+                id: $r.eventDataId,
+                category: ["configuration"],
+                type: $type,
+                outcome: $outcome
+              },
+
+              cloud: {
+                provider: "azure",
+                region: $r.location,
+                account: { id: $r.subscriptionId }
+              },
+
+              user: {
+                name: $caller,
+                id: $caller_uid
+              },
+
+              source: {
+                address: $caller_ip,
+                ip: ( if is_ip($caller_ip) then $caller_ip else null end )
+              },
+
+              related: {
+                ip: ( if is_ip($caller_ip) then [$caller_ip] else [] end ),
+                user: ( [ $caller, $caller_uid ] | map(select(. != null)) | unique )
+              }
+            }
+          | prune

--- a/ecs/v9.5.0/microsoft/microsoft-entra-id.yaml
+++ b/ecs/v9.5.0/microsoft/microsoft-entra-id.yaml
@@ -1,0 +1,116 @@
+name: "Microsoft Entra ID Sign-in Logs to ECS v9.5.0"
+description: "Normalizes Microsoft Entra ID (Azure AD) sign-in log records into the Elastic Common Schema (ECS) v9.5.0 authentication fields (event, user, source, source.geo, host, user_agent, cloud, organization, related)."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "microsoft-entra-id"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "microsoft"
+  - "entra-id"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # Microsoft Entra ID sign-in logs -> ECS v9.5.0 (authentication)
+          # Input: ONE Entra ID sign-in record per invocation (Microsoft Graph
+          #   auditLogs/signIns resource shape) from the `microsoft-entra-id`
+          #   input connector.
+          # =================================================================
+
+          # An ES `ip`-mapped field rejects the whole document if handed a
+          # hostname, so guard every ip field.
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+          | ( $r.status // {} ) as $st
+          | ( $r.deviceDetail // {} ) as $dd
+          | ( $r.location // {} ) as $loc
+          | ( ($st.errorCode // 0) == 0 ) as $ok
+          | ( $r.ipAddress ) as $ip
+          | {
+              ecs: { version: "9.5.0" },
+
+              "@timestamp": $r.createdDateTime,
+
+              event: {
+                kind: "event",
+                module: "azure",
+                dataset: "azure.signinlogs",
+                provider: "microsoft-entra-id",
+                # correlationId ties the multiple rows of one sign-in together.
+                id: $r.id,
+                action: "user-signin",
+                category: ["authentication"],
+                # An interactive sign-in is a session beginning -> start.
+                type: ["start"],
+                outcome: ( if $ok then "success" else "failure" end ),
+                reason: ($st.failureReason // $st.additionalDetails),
+                code: (($st.errorCode // 0) | tostring)
+              },
+
+              user: {
+                id: $r.userId,
+                name: $r.userPrincipalName,
+                email: $r.userPrincipalName,
+                full_name: $r.userDisplayName
+              },
+
+              source: {
+                address: $ip,
+                ip: ( if is_ip($ip) then $ip else null end ),
+                geo: {
+                  city_name: $loc.city,
+                  region_name: $loc.state,
+                  country_iso_code: $loc.countryOrRegion,
+                  # ES geo_point as a "lat,lon" string leaf (a nested
+                  # {lat,lon} object would surface as unknown sub-fields to
+                  # the static validator).
+                  location: (
+                    if ($loc.geoCoordinates.longitude != null and $loc.geoCoordinates.latitude != null)
+                    then (($loc.geoCoordinates.latitude | tostring) + "," + ($loc.geoCoordinates.longitude | tostring))
+                    else null end
+                  )
+                }
+              },
+
+              host: {
+                id: $dd.deviceId,
+                name: $dd.displayName,
+                os: { full: $dd.operatingSystem }
+              },
+
+              user_agent: { original: $r.clientAppUsed },
+
+              cloud: {
+                provider: "azure",
+                account: { id: ($r.homeTenantId // $r.resourceTenantId) }
+              },
+
+              organization: { id: ($r.resourceTenantId // $r.homeTenantId) },
+
+              related: {
+                ip: ( if is_ip($ip) then [$ip] else [] end ),
+                user: ( [ $r.userPrincipalName, $r.userDisplayName, $r.userId ]
+                        | map(select(. != null)) | unique ),
+                hosts: ( [ $dd.displayName ] | map(select(. != null)) | unique )
+              }
+            }
+          | prune

--- a/ecs/v9.5.0/monad/monad-logs.yaml
+++ b/ecs/v9.5.0/monad/monad-logs.yaml
@@ -1,0 +1,73 @@
+name: "Monad Organization Logs to ECS v9.5.0"
+description: "Transforms Monad Organization Logs (monad-logs) into Elastic Common Schema (ECS) v9.5.0, covering event, http, url, user, client, user_agent, and related field sets."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "monad-logs"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "monad"
+  - "organization"
+  - "logs"
+  - "api-activity"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # Monad Organization Logs -> ECS v9.5.0 (nested document)
+          . as $r
+          | def is_ip($s):
+              ($s | type) == "string"
+              and ($s | test("^[0-9]{1,3}(\\.[0-9]{1,3}){3}$|:"));
+            ({
+              "GET": "access",
+              "POST": "creation",
+              "PUT": "change",
+              "PATCH": "change",
+              "DELETE": "deletion"
+            }[$r.method] // "info") as $etype
+          | (
+              if ($r.status | tonumber) >= 200 and ($r.status | tonumber) < 400 then "success"
+              else "failure"
+              end
+            ) as $outcome
+          | {
+              "@timestamp": $r.timestamp,
+              ecs: { version: "9.5.0" },
+              event: {
+                kind: "event",
+                category: ["api"],
+                type: [$etype],
+                action: ($r.method + " " + $r.resource),
+                id: $r.id,
+                outcome: $outcome,
+                provider: "monad",
+                dataset: "monad.organization_logs"
+              },
+              http: {
+                request: { method: $r.method },
+                response: { status_code: ($r.status | tonumber | floor) }
+              },
+              url: { path: $r.resource },
+              user: { email: $r.user_email },
+              client: (if is_ip($r.client_ip) then { ip: $r.client_ip } else {} end),
+              user_agent: { original: $r.client_info },
+              related: {
+                user: ([$r.user_email] | map(select(. != null)) | unique),
+                ip: ([ (if is_ip($r.client_ip) then $r.client_ip else null end) ] | map(select(. != null)) | unique)
+              },
+              labels: (
+                { log_version: $r.log_version, additional_info: $r.additional_info }
+                | with_entries(select(.value != null))
+              )
+            }
+          | walk(
+              if type == "object" then with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then map(select(. != null))
+              else .
+              end
+            )

--- a/ecs/v9.5.0/nist/nist-cve.yaml
+++ b/ecs/v9.5.0/nist/nist-cve.yaml
@@ -1,0 +1,105 @@
+name: "NIST NVD CVE to ECS v9.5.0"
+description: "Transforms NIST NVD CVE records into Elastic Common Schema (ECS) v9.5.0 documents, populating the event.* categorization and vulnerability.* field sets."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "nist-cve"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "nist"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # NIST NVD CVE -> ECS v9.5.0 (nested document).
+          # event.kind=enrichment, event.category=[vulnerability],
+          # event.type=[info] (the only type ECS allows for that category).
+          # Input: one NVD CVE record ({cve:{...}}) per invocation.
+          # ---------------------------------------------------------------
+
+          # NVD timestamps lack a zone (e.g. "2024-08-13T18:15:10.017");
+          # force a Z so downstream ES parses them as UTC.
+          def norm_ts($ts):
+            if $ts == null then null
+            elif ($ts | endswith("Z")) then $ts
+            else ($ts + "Z") end;
+
+          . as $r
+          | ($r.cve // $r) as $c
+          | (($c.descriptions // []) | (map(select(.lang == "en")) | .[0].value) // (.[0].value)) as $desc
+          | (($c.metrics.cvssMetricV31 // $c.metrics.cvssMetricV30 // $c.metrics.cvssMetricV2 // []) | .[0]) as $m
+          | ($m.cvssData // {}) as $cd
+          | ([ ($c.weaknesses // [])[].description[]? | select(.value | test("^CWE-")) | .value ] | unique) as $cwes
+          | ([ ($c.references // [])[].url ] | unique) as $refs
+          | ([ ($c.configurations // [])[].nodes[]?.cpeMatch[]?.criteria ] | unique) as $cpes
+          | {
+              "@timestamp": norm_ts($c.published),
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "enrichment",
+                "category": ["vulnerability"],
+                "type": ["info"],
+                "outcome": "unknown",
+                "id": $c.id,
+                "created": norm_ts($c.lastModified),
+                "provider": "nvd",
+                "module": "nist",
+                "dataset": "nist.cve",
+                "reference": ($refs | first),
+                "url": ($refs | first)
+              },
+
+              "message": $desc,
+
+              "vulnerability": {
+                "id": $c.id,
+                "enumeration": "CVE",
+                "classification": (if $cd.version != null then "CVSS" else null end),
+                "description": $desc,
+                "severity": $cd.baseSeverity,
+                "reference": ($refs | first),
+                "scanner": { "vendor": "NIST NVD" },
+                "status": $c.vulnStatus,
+                "category": $cwes,
+                "score": {
+                  "base": $cd.baseScore,
+                  "version": $cd.version
+                }
+              },
+
+              # Vendor namespace (ECS permits custom top-level keys) for the
+              # NVD-specific detail with no ECS home. Nested blobs kept simple.
+              "nist": {
+                "cve": {
+                  "source_identifier": $c.sourceIdentifier,
+                  "vuln_status": $c.vulnStatus,
+                  "published": norm_ts($c.published),
+                  "last_modified": norm_ts($c.lastModified),
+                  "cwe": $cwes,
+                  "cpe": $cpes,
+                  "cvss_vector": $cd.vectorString,
+                  "exploitability_score": $m.exploitabilityScore,
+                  "impact_score": $m.impactScore
+                }
+              },
+
+              "related": {
+                "hosts": []
+              }
+            }
+          # Single end-of-pipeline recursive prune: drop nulls, {}, [] (ES
+          # rejects nulls; the doc is deeply nested).
+          | walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            )

--- a/ecs/v9.5.0/okta/okta-systemlog.yaml
+++ b/ecs/v9.5.0/okta/okta-systemlog.yaml
@@ -1,0 +1,128 @@
+name: "Okta System Log to ECS v9.5.0"
+description: "Normalizes Okta System Log records into the Elastic Common Schema (ECS) v9.5.0 core security fields (event, user, source, user_agent, url, related), mapping Okta session/authentication events to the authentication + session categories."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "okta-systemlog"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "okta"
+  - "authentication"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # Okta System Log  ->  ECS v9.5.0  (core security fields)
+          # Input: ONE Okta System Log record per invocation.
+          #   .published      -> @timestamp
+          #   .eventType      -> event.action
+          #   .uuid           -> event.id
+          #   .displayMessage -> message
+          #   .outcome.result -> event.outcome
+          #   actor           -> user.*
+          #   client.ipAddress-> source.ip / source.address
+          #   client.userAgent-> user_agent.*
+          # =================================================================
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+          | ($r.eventType // "") as $et
+          | ($r.actor // {}) as $actor
+          | ($r.client // {}) as $client
+          | ($client.userAgent // {}) as $ua
+          | ($client.geographicalContext // {}) as $geo
+          | ($r.outcome.result // "") as $result
+
+          | ( if ($result | ascii_upcase) == "SUCCESS" then "success"
+              elif $result == "" then "unknown"
+              elif ($result | ascii_upcase) | test("FAIL|DENY|DENIED") then "failure"
+              else "unknown" end ) as $outcome
+
+          # Session lifecycle -> authentication + session categories.
+          | ( if ($et | test("^user\\.(session|authentication)")) then ["authentication","session"]
+              elif ($et | test("^user\\.session\\.end") or ($et | contains("logout"))) then ["authentication","session"]
+              else ["iam"] end ) as $category
+
+          | ( if $category == ["iam"] then ["info"]
+              elif ($et | test("\\.(end|expire|clear)$") or ($et | contains("logout"))) then ["end"]
+              else ["start"] end ) as $type
+
+          | {
+              "@timestamp": $r.published,
+              ecs: { version: "9.5.0" },
+
+              event: {
+                kind: "event",
+                provider: "okta",
+                module: "okta",
+                dataset: "okta.system",
+                action: $r.eventType,
+                id: $r.uuid,
+                code: $r.legacyEventType,
+                category: $category,
+                type: $type,
+                outcome: $outcome
+              },
+
+              message: $r.displayMessage,
+
+              user: {
+                id: $actor.id,
+                name: $actor.alternateId,
+                full_name: $actor.displayName,
+                email: $actor.alternateId
+              },
+
+              source: {
+                address: $client.ipAddress,
+                ip: ( if is_ip($client.ipAddress) then $client.ipAddress else null end ),
+                geo: {
+                  city_name: $geo.city,
+                  region_name: $geo.state,
+                  country_name: $geo.country,
+                  postal_code: $geo.postalCode,
+                  location: (
+                    ($geo.geolocation // {}) as $ll
+                    | if ($ll.lat != null and $ll.lon != null)
+                      then "\($ll.lat),\($ll.lon)" else null end
+                  )
+                },
+                as: {
+                  number: $r.securityContext.asNumber,
+                  organization: { name: $r.securityContext.asOrg }
+                }
+              },
+
+              user_agent: {
+                original: $ua.rawUserAgent,
+                name: $ua.browser,
+                os: { full: $ua.os }
+              },
+
+              url: {
+                path: $r.debugContext.debugData.requestUri
+              },
+
+              related: {
+                ip: ( if is_ip($client.ipAddress) then [$client.ipAddress] else [] end ),
+                user: ( [ $actor.alternateId, $actor.displayName ]
+                        | map(select(. != null)) | unique )
+              }
+            }
+          | prune

--- a/ecs/v9.5.0/okta/okta-users.yaml
+++ b/ecs/v9.5.0/okta/okta-users.yaml
@@ -1,0 +1,88 @@
+name: "Okta Users to ECS v9.5.0"
+description: "Maps Okta Users directory records into Elastic Common Schema (ECS) v9.5.0 nested documents, covering event.*, user.*, related.*, and organization.* field sets."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "okta-users"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "okta"
+  - "users"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Okta Users (directory) -> ECS v9.5.0 (nested).
+          # User inventory snapshot: event.kind=state, category=[iam],
+          # type=[user,info], outcome=success.
+          # ---------------------------------------------------------------
+          def to_iso($ts):
+            if $ts == null then null
+            else ($ts | gsub("\\.[0-9]+Z$"; "Z"))
+            end;
+
+          . as $r |
+          ($r.profile // {}) as $p |
+          {
+            "@timestamp": (to_iso($r.lastUpdated // $r.created)),
+            "ecs": { "version": "9.5.0" },
+
+            "event": {
+              "kind": "state",
+              "category": ["iam"],
+              "type": ["user", "info"],
+              "outcome": "success",
+              "action": "user-inventory",
+              "provider": "okta",
+              "module": "okta",
+              "dataset": "okta.users",
+              "id": $r.id,
+              "created": (to_iso($r.created))
+            },
+
+            "user": {
+              "id":        $r.id,
+              "name":      ($p.login // $p.email),
+              "email":     $p.email,
+              "full_name": ($p.displayName // (($p.firstName // "") + " " + ($p.lastName // "") | ltrimstr(" ") | rtrimstr(" "))),
+              "domain":    (($p.email // $p.login // "") | (split("@") | if length > 1 then .[1] else null end))
+            },
+
+            "organization": {
+              "name": $p.organization
+            },
+
+            "source": {
+              "user": {
+                "id":    $r.id,
+                "name":  ($p.login // $p.email),
+                "email": $p.email
+              }
+            },
+
+            "okta": {
+              "user": {
+                "status":           $r.status,
+                "title":            $p.title,
+                "department":       $p.department,
+                "employee_number":  $p.employeeNumber,
+                "manager":          $p.manager,
+                "user_type":        $p.userType,
+                "last_login":       (to_iso($r.lastLogin)),
+                "status_changed":   (to_iso($r.statusChanged)),
+                "password_changed": (to_iso($r.passwordChanged)),
+                "activated":        (to_iso($r.activated)),
+                "credential_provider": ($r.credentials.provider.type // null)
+              }
+            },
+
+            "related": {
+              "user": ([$p.login, $p.email, $r.id, $p.displayName] | map(select(. != null and . != "")) | unique)
+            }
+          }
+          | walk(if type == "object" then with_entries(select(.value != null and .value != "" and .value != {} and .value != [])) else . end)

--- a/ecs/v9.5.0/opencti/opencti-indicators.yaml
+++ b/ecs/v9.5.0/opencti/opencti-indicators.yaml
@@ -1,0 +1,120 @@
+name: "OpenCTI Indicators to ECS v9.5.0"
+description: "Maps OpenCTI (STIX 2.1) threat-intelligence Indicator records into Elastic Common Schema (ECS) v9.5.0, populating the event categorization and the threat.indicator.* / threat.feed.* field sets."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "opencti-indicators"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "opencti"
+  - "indicators"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # OpenCTI (STIX 2.1) Indicator -> ECS v9.5.0 (nested document).
+          # Threat intel -> event.kind:enrichment, category:[threat],
+          # type:[indicator]; the indicator itself lives under threat.indicator.*
+          # One jq pass, bind-once, is_ip guard, single walk-based prune.
+          # ---------------------------------------------------------------
+          . as $r
+          | def is_ip($s):
+              ($s | type) == "string"
+              and ($s | test("^([0-9]{1,3}\\.){3}[0-9]{1,3}$|:"));
+          def conf($c):
+              if $c == null then null
+              elif $c >= 70 then "High"
+              elif $c >= 40 then "Medium"
+              elif $c >= 1  then "Low"
+              else "None" end;
+          ($r.x_opencti_main_observable_type // "") as $mot
+          | (if   ($mot | test("Domain";"i"))        then "domain-name"
+             elif ($mot | test("IPv4";"i"))           then "ipv4-addr"
+             elif ($mot | test("IPv6";"i"))           then "ipv6-addr"
+             elif ($mot | test("Url";"i"))            then "url"
+             elif ($mot | test("Hostname";"i"))       then "domain-name"
+             elif ($mot | test("StixFile|File";"i"))  then "file"
+             elif ($mot | test("Email-Addr";"i"))     then "email-addr"
+             elif ($mot | test("Certificate|X509";"i")) then "x509-certificate"
+             else ($mot | ascii_downcase) end) as $ind_type
+          | ($r.name // $r.pattern // $r.id) as $val
+          | ($r.objectMarking[0].definition // null) as $tlp_def
+          | {
+              "@timestamp": ($r.valid_from // $r.created // $r.created_at),
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "enrichment",
+                "category": ["threat"],
+                "type": ["indicator"],
+                "id": $r.id,
+                "created": ($r.created_at // $r.created),
+                "module": "opencti",
+                "dataset": "opencti.indicators",
+                "provider": (($r.createdBy.name) // "OpenCTI")
+              },
+
+              "threat": {
+                "feed": {
+                  "name": (($r.createdBy.name) // "OpenCTI"),
+                  "reference": ($r.externalReferences[0].url // null)
+                },
+                "indicator": {
+                  "id": [$r.id],
+                  "name": $val,
+                  "type": $ind_type,
+                  "description": ($r.description // null),
+                  "confidence": conf($r.confidence),
+                  "first_seen": ($r.valid_from // null),
+                  "last_seen": ($r.valid_until // null),
+                  "modified_at": ($r.modified // $r.updated_at // null),
+                  "provider": (($r.createdBy.name) // null),
+                  "reference": ($r.externalReferences[0].url // null),
+                  "sightings": null,
+                  "marking": {
+                    "tlp": (if $tlp_def != null
+                            then ($tlp_def | ltrimstr("TLP:"))
+                            else null end)
+                  },
+                  "ip": (if $ind_type == "ipv4-addr" or $ind_type == "ipv6-addr"
+                         then (if is_ip($val) then $val else null end)
+                         else null end),
+                  "url": (if $ind_type == "url"
+                          then { "original": $val, "full": $val }
+                          else (if $ind_type == "domain-name"
+                                then { "domain": $val }
+                                else null end)
+                          end)
+                }
+              },
+
+              "related": {
+                "hosts": (if $ind_type == "domain-name" then [$val] else null end),
+                "ip": (if ($ind_type | startswith("ip")) and is_ip($val) then [$val] else null end)
+              },
+
+              "tags": ($r.labels // null),
+
+              "opencti": {
+                "score": ($r.x_opencti_score // null),
+                "detection": ($r.x_opencti_detection // null),
+                "pattern": ($r.pattern // null),
+                "pattern_type": ($r.pattern_type // null),
+                "indicator_types": ($r.indicator_types // null),
+                "revoked": ($r.revoked // null),
+                "kill_chain_phases": ($r.killChainPhases // null),
+                "main_observable_type": ($r.x_opencti_main_observable_type // null)
+              }
+            }
+          | walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            )

--- a/ecs/v9.5.0/semgrep/semgrep-chain-findings.yaml
+++ b/ecs/v9.5.0/semgrep/semgrep-chain-findings.yaml
@@ -1,0 +1,90 @@
+name: "Semgrep Supply Chain Findings to ECS v9.5.0"
+description: "Maps Semgrep Supply Chain (dependency) Findings into Elastic Common Schema (ECS) v9.5.0, populating the event, vulnerability, package, file, rule, and observer field sets."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "semgrep-chain-findings"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "semgrep"
+  - "supply-chain"
+  - "vulnerability"
+  - "findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Semgrep Supply Chain Findings -> ECS v9.5.0 (nested).
+          # event.kind=alert; category=[vulnerability,package]; type=[info].
+          # One jq pass; single end-of-pipeline walk prune.
+          # ---------------------------------------------------------------
+          . as $r
+          | ($r.found_dependency // {}) as $dep
+          | ($r.rule.cwe_names[0] // null) as $cwe0
+          | ($r.rule.vulnerability_identifier // null) as $cve
+          | {
+              "@timestamp": $r.created_at,
+              "ecs": { "version": "9.5.0" },
+              "message": $r.rule_message,
+              "tags": $r.categories,
+
+              "event": {
+                "kind": "alert",
+                "category": ["vulnerability", "package"],
+                "type": ["info"],
+                "outcome": "unknown",
+                "id": ($r.id | tostring),
+                "created": $r.created_at,
+                "provider": "semgrep",
+                "module": "semgrep",
+                "dataset": "semgrep.supply_chain",
+                "reference": ($r.repository.url // null),
+                "original": ($r | tojson)
+              },
+
+              "vulnerability": {
+                "id": $cve,
+                "description": $r.rule_message,
+                "severity": $r.severity,
+                "category": ["supply-chain"],
+                "classification": ($cwe0 | if . != null then (split(":")[0]) else null end),
+                "enumeration": (if $cve != null then "CVE" else null end),
+                "reference": ($r.rule.references // null),
+                "scanner": { "vendor": "Semgrep" },
+                "status": ($r.status // $r.state)
+              },
+
+              "package": {
+                "name": ($dep.package // null),
+                "version": ($dep.version // null),
+                "type": ($dep.ecosystem // null),
+                "reference": ($dep.lockfile_line_url // null)
+              },
+
+              "file": {
+                "path": ($r.location.file_path // null),
+                "name": (if ($r.location.file_path // null) != null then ($r.location.file_path | split("/")[-1]) else null end)
+              },
+
+              "rule": {
+                "id": $r.rule_name,
+                "name": $r.rule_name,
+                "description": $r.rule_message,
+                "reference": ($r.rule.references // null)
+              },
+
+              "observer": {
+                "vendor": "Semgrep",
+                "product": "Semgrep Supply Chain"
+              },
+
+              "related": {
+                "hosts": ([$r.repository.name] | map(select(. != null)) | unique)
+              }
+            }
+          | walk(if type == "object" then with_entries(select(.value != null and .value != [] and .value != {} and .value != "")) else . end)

--- a/ecs/v9.5.0/semgrep/semgrep-code-findings.yaml
+++ b/ecs/v9.5.0/semgrep/semgrep-code-findings.yaml
@@ -1,0 +1,83 @@
+name: "Semgrep Code Vulnerability Findings to ECS v9.5.0"
+description: "Maps a Semgrep Code Vulnerability Finding into an Elastic Common Schema (ECS) v9.5.0 document, populating event categorization, the vulnerability.* and rule.* field sets, and file.* source-location fields."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "semgrep-code-findings"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "semgrep"
+  - "code"
+  - "vulnerability"
+  - "findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          . as $r
+          | ($r.severity // "" | ascii_downcase) as $sev
+          | (if $sev == "critical" then 99
+             elif $sev == "high" then 73
+             elif $sev == "medium" then 47
+             elif $sev == "low" then 21
+             elif $sev == "info" then 1
+             else 0 end) as $sev_num
+          | (($r.rule.cwe_names // []) | map(select(. != null))) as $cwes
+          | ($cwes | map(split(":")[0] | ascii_upcase) | map(select(startswith("CWE")))) as $cwe_ids
+          | ($r.location.file_path // "") as $fp
+          | {
+              "@timestamp": ($r.created_at // $r.state_updated_at),
+              "ecs": { "version": "9.5.0" },
+              "message": ($r.rule_message // $r.rule_name),
+              "event": {
+                "kind": "alert",
+                "category": ["vulnerability"],
+                "type": ["info"],
+                "outcome": "unknown",
+                "provider": "semgrep",
+                "module": "semgrep",
+                "id": ($r.id | tostring),
+                "severity": $sev_num,
+                "url": $r.line_of_code_url,
+                "created": ($r.created_at // $r.state_updated_at),
+                "reference": $r.line_of_code_url
+              },
+              "vulnerability": {
+                "id": ($cwe_ids[0] // null),
+                "category": (($r.rule.vulnerability_classes // []) + ($r.categories // []) | unique),
+                "classification": (if ($cwe_ids | length) > 0 then "CWE" else null end),
+                "enumeration": (if ($cwe_ids | length) > 0 then "CWE" else null end),
+                "description": ($r.rule_message // $r.rule_name),
+                "reference": (($r.rule.owasp_names // []) + [$r.line_of_code_url] | map(select(. != null)) | unique),
+                "scanner": { "vendor": "Semgrep" },
+                "severity": $r.severity,
+                "status": ($r.status // $r.state)
+              },
+              "rule": {
+                "id": $r.rule_name,
+                "name": $r.rule_name,
+                "description": ($r.rule.message // $r.rule_message),
+                "category": ($r.rule.category // null),
+                "ruleset": (($r.sourcing_policy.name) // null)
+              },
+              "file": {
+                "path": (if $fp != "" then $fp else null end),
+                "name": (if $fp != "" then ($fp | split("/")[-1]) else null end),
+                "directory": (if ($fp | index("/")) then ($fp | split("/")[:-1] | join("/")) else null end),
+                "extension": (if ($fp | index(".")) then ($fp | split(".")[-1]) else null end)
+              },
+              "url": {
+                "full": $r.line_of_code_url,
+                "original": $r.line_of_code_url
+              },
+              "labels": {
+                "confidence": $r.confidence,
+                "triage_state": $r.triage_state,
+                "repository": $r.repository.name
+              }
+            }
+          | walk(if type == "object" then with_entries(select(.value != null and .value != "" and .value != [] and .value != {})) else . end)

--- a/ecs/v9.5.0/snyk/snyk-issues.yaml
+++ b/ecs/v9.5.0/snyk/snyk-issues.yaml
@@ -1,0 +1,78 @@
+name: "Snyk Issue Findings to ECS v9.5.0"
+description: "Transforms Snyk Issue Findings into Elastic Common Schema (ECS) v9.5.0 documents, populating event categorization, the vulnerability.* and package.* field sets, and related.* aggregation."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "snyk-issues"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "snyk"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Snyk /issues record -> ECS v9.5.0 (nested). One record per call.
+          # event.kind: alert ; event.category: [vulnerability] ; type: [info]
+          # ---------------------------------------------------------------
+          def to_iso($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then ($ts | todateiso8601)
+            else $ts end;
+
+          . as $r
+          | ($r.attributes // {}) as $a
+          | ($a.coordinates[0].representations[0].dependency // {}) as $dep
+          | ( [ $a.problems[]? | select(.source == "NVD") | .id ] | first ) as $cve
+          | ( [ $a.classes[]?  | select(.source == "CWE") | .id ] | first ) as $cwe
+          | ( [ $a.severities[]? | select(.score != null) | .score ] | first ) as $cvss
+          | {
+              "@timestamp": (to_iso($a.updated_at) // to_iso($a.created_at)),
+              "ecs": { "version": "9.5.0" },
+              "event": {
+                "kind": "alert",
+                "category": [ "vulnerability" ],
+                "type": [ "info" ],
+                "outcome": "unknown",
+                "id": $r.id,
+                "created": to_iso($a.created_at),
+                "provider": "snyk",
+                "module": "snyk",
+                "dataset": "snyk.issues",
+                "severity": (
+                  { "info": 1, "low": 2, "medium": 3, "high": 4, "critical": 5 }[$a.effective_severity_level] // 0
+                ),
+                "url": ($a.problems[0].url // null),
+                "reference": ($a.problems[0].url // null)
+              },
+              "vulnerability": {
+                "id": ($cve // $a.key),
+                "enumeration": (if $cve != null then "CVE" else null end),
+                "classification": (if $cwe != null then "CWE" else null end),
+                "reference": ($a.problems[0].url // null),
+                "report_id": $a.key,
+                "description": $a.description,
+                "category": [ $a.type ],
+                "severity": $a.effective_severity_level,
+                "status": $a.status,
+                "scanner": { "vendor": "Snyk" },
+                "score": (
+                  if $cvss != null then { "base": $cvss, "version": "3.1" } else null end
+                )
+              },
+              "package": {
+                "name": $dep.package_name,
+                "version": $dep.package_version
+              },
+              "message": $a.title,
+              "tags": [ $a.type ],
+              "related": {
+                "hosts": ( [ $dep.package_name ] | map(select(. != null)) | unique )
+              }
+            }
+            | walk( if type == "object" then with_entries(select(.value != null and .value != [] and .value != {} and .value != "")) else . end )

--- a/ecs/v9.5.0/tenable/tenable-assets.yaml
+++ b/ecs/v9.5.0/tenable/tenable-assets.yaml
@@ -1,0 +1,96 @@
+name: "Tenable Assets to ECS v9.5.0"
+description: "Maps Tenable Vulnerability Management asset inventory records into Elastic Common Schema (ECS) v9.5.0, covering the event, host, os, cloud, and related field sets as an asset snapshot."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "tenable-assets"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "tenable"
+  - "asset"
+  - "inventory"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # Tenable asset inventory -> ECS v9.5.0 (nested). Asset snapshot:
+          # event.kind=asset, category=[host], type=[info].
+          def is_ip($s):
+            ($s | type) == "string" and
+            ( ($s | test("^[0-9]{1,3}(\\.[0-9]{1,3}){3}$"))
+              or ($s | test("^[0-9A-Fa-f:]+:[0-9A-Fa-f:]*$")) );
+          . as $r |
+          ( ($r.ipv4s // []) + ($r.ipv6s // []) | map(select(is_ip(.))) | unique ) as $ips |
+          ( ($r.hostnames // []) + ($r.netbios_names // []) + ($r.fqdns // []) | unique ) as $hosts |
+          ( ($r.operating_systems // [])[0] ) as $osfull |
+          ( ($osfull // "" | ascii_downcase) ) as $osl |
+          {
+            "@timestamp": ($r.updated_at // $r.last_seen),
+            "ecs": { "version": "9.5.0" },
+            "event": {
+              "kind": "asset",
+              "category": ["host"],
+              "type": ["info"],
+              "outcome": "unknown",
+              "module": "tenable",
+              "dataset": "tenable.asset",
+              "provider": "Tenable Vulnerability Management",
+              "id": $r.id,
+              "created": $r.first_seen,
+              "ingested": $r.last_seen
+            },
+            "host": {
+              "id": $r.id,
+              "name": ($hosts[0]),
+              "hostname": (($r.hostnames // [])[0]),
+              "domain": (($r.fqdns // [])[0]),
+              "ip": (if ($ips | length) > 0 then $ips else null end),
+              "mac": (if (($r.mac_addresses // []) | length) > 0 then $r.mac_addresses else null end),
+              "os": (
+                if $osfull then {
+                  "full": $osfull,
+                  "name": $osfull,
+                  "type": (
+                    if ($osl | contains("windows")) then "windows"
+                    elif ($osl | contains("linux")) then "linux"
+                    elif ($osl | contains("mac")) then "macos"
+                    elif ($osl | contains("android")) then "android"
+                    elif ($osl | contains("ios")) then "ios"
+                    else null end
+                  ),
+                  "platform": (
+                    if ($osl | contains("windows")) then "windows"
+                    elif ($osl | contains("linux")) then "linux"
+                    elif ($osl | contains("mac")) then "darwin"
+                    else null end
+                  )
+                } else null end
+              )
+            },
+            "cloud": (
+              if ($r.aws_region != null or $r.aws_ec2_instance_id != null) then {
+                "provider": "aws",
+                "region": $r.aws_region,
+                "availability_zone": $r.aws_availability_zone,
+                "account": (if $r.aws_owner_id then { "id": $r.aws_owner_id } else null end),
+                "instance": (if $r.aws_ec2_instance_id then { "id": $r.aws_ec2_instance_id } else null end),
+                "machine": (if $r.aws_ec2_instance_type then { "type": $r.aws_ec2_instance_type } else null end)
+              } else null end
+            ),
+            "related": {
+              "ip": $ips,
+              "hosts": $hosts
+            }
+          }
+          # Single end-of-pipeline prune: drop null / {} / [] so ES accepts the doc.
+          | walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != "" and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            )

--- a/ecs/v9.5.0/tenable/tenable-vulnerabilities.yaml
+++ b/ecs/v9.5.0/tenable/tenable-vulnerabilities.yaml
@@ -1,0 +1,156 @@
+name: "Tenable Vulnerability Findings to ECS v9.5.0"
+description: "Normalizes individual Tenable Vulnerability Management finding records into the Elastic Common Schema (ECS) v9.5.0 security fields (event, vulnerability, host, cloud, related), modeling each scan finding as an event.kind:alert in the vulnerability category."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "tenable-vulnerabilities"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "tenable"
+  - "vulnerability"
+  - "findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # Tenable Vulnerability Management  ->  ECS v9.5.0
+          #
+          # Input: ONE Tenable VM vulnerability finding per invocation.
+          # ECS has no "finding" concept: a vulnerability finding maps to
+          #   event.kind: alert + event.category: [vulnerability] (type info)
+          #   + the vulnerability.* field set. Host / cloud context comes from
+          #   the Tenable asset block.
+          # =================================================================
+
+          # An ES `ip`-mapped field rejects a document handed a hostname, so
+          # guard every ip-typed assignment.
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          # Tenable timestamps carry fractional seconds + Z; ECS @timestamp is
+          # ISO-8601 and tolerates the fraction, so pass strings through as-is.
+
+          # ECS host.os.type closed vocabulary from the Tenable OS string.
+          def os_type($o):
+            ($o // "" | ascii_downcase) as $s |
+            if   ($s | test("windows")) then "windows"
+            elif ($s | test("mac os|macos|os x")) then "macos"
+            elif ($s | test("android")) then "android"
+            elif ($s | test("ios")) then "ios"
+            elif ($s | test("linux|ubuntu|debian|red ?hat|centos|suse|fedora")) then "linux"
+            else null end;
+          def os_family($o):
+            ($o // "" | ascii_downcase) as $s |
+            if   ($s | test("windows")) then "windows"
+            elif ($s | test("mac os|macos|os x")) then "macos"
+            elif ($s | test("ubuntu|debian")) then "debian"
+            elif ($s | test("red ?hat|centos|fedora")) then "redhat"
+            elif ($s | test("suse")) then "suse"
+            elif ($s | test("linux")) then "linux"
+            else null end;
+
+          # Recursively drop null values and empty objects/arrays.
+          def prune:
+            walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then
+                map(select(. != null))
+              else . end
+            );
+
+          . as $r
+          | ( $r.plugin // {} ) as $p
+          | ( $r.asset  // {} ) as $a
+          | ( $a.operating_system // [] | first ) as $os
+
+          # CVEs: plugin.cve (prefixed) unioned with any CVE cross-references.
+          | ( ( ($p.cve // [])
+                + [ ($p.xrefs // [])[] | select(.type == "CVE") | "CVE-" + (.id | ltrimstr("CVE-")) ] )
+              | unique ) as $cves
+          # CWEs from cross-references -> vulnerability.enumeration / category.
+          | ( [ ($p.xrefs // [])[] | select(.type == "CWE") | "CWE-" + (.id | ltrimstr("CWE-")) ]
+              | unique ) as $cwes
+
+          # Cloud provider from the Tenable CSP asset identifiers.
+          | ( if   $a.aws_ec2_instance_id != null then "aws"
+              elif ($a.azure_vm_id // $a.azure_resource_id) != null then "azure"
+              elif ($a.gcp_instance_id // $a.gcp_project_id) != null then "gcp"
+              else null end ) as $cloud_provider
+
+          # A Tenable finding is a scanner assertion, not a success/failure
+          # action; ECS outcome is `unknown` for that.
+          | {
+              ecs: { version: "9.5.0" },
+
+              "@timestamp": ($r.scan.started_at // $r.last_found // $r.first_found),
+
+              event: {
+                kind: "alert",
+                module: "tenable",
+                dataset: "tenable.vulnerability",
+                provider: "Tenable Vulnerability Management",
+                category: ["vulnerability"],
+                type: ["info"],
+                outcome: "unknown",
+                severity: $r.severity_id,
+                id: ($p.id | tostring),
+                created: $r.indexed,
+                start: $r.first_found,
+                end: $r.last_found,
+                reference: ($p.see_also // [] | first),
+                url: ($p.see_also // [] | first)
+              },
+
+              vulnerability: {
+                id: ( if ($cves | length) > 0 then $cves else [($p.id | tostring)] end ),
+                enumeration: ( if ($cves | length) > 0 then "CVE"
+                               elif ($cwes | length) > 0 then "CWE" else null end ),
+                category: ( ($cwes + [$p.family]) | map(select(. != null)) | unique ),
+                classification: "CVSS",
+                description: ($p.synopsis // $p.description),
+                reference: ($p.see_also // [] | first),
+                report_id: ($p.id | tostring),
+                scanner: { vendor: "Tenable" },
+                severity: $r.severity,
+                score: (
+                  { version: (if $p.cvss3_base_score != null then "3.0"
+                              elif $p.cvss_base_score != null then "2.0" else null end),
+                    base: ($p.cvss3_base_score // $p.cvss_base_score) }
+                )
+              },
+
+              host: {
+                hostname: ($a.hostname // $a.netbios_name),
+                name: ($a.fqdn // $a.hostname // $a.netbios_name),
+                id: $a.uuid,
+                ip: ( [ $a.ipv4, $a.ipv6 ] | map(select(is_ip(.))) ),
+                mac: ( if $a.mac_address != null then [$a.mac_address] else null end ),
+                os: ( if $os != null then {
+                        full: $os,
+                        name: $os,
+                        type: os_type($os),
+                        family: os_family($os)
+                      } else null end )
+              },
+
+              cloud: ( if $cloud_provider != null then {
+                  provider: $cloud_provider,
+                  region: $a.aws_region,
+                  instance: { id: ($a.aws_ec2_instance_id // $a.azure_vm_id // $a.gcp_instance_id) },
+                  account: { id: ($a.aws_owner_id // $a.gcp_project_id) }
+                } else null end ),
+
+              related: {
+                ip: ( [ $a.ipv4, $a.ipv6 ] | map(select(is_ip(.))) ),
+                hosts: ( [ $a.hostname, $a.fqdn, $a.netbios_name ]
+                         | map(select(. != null)) | unique )
+              }
+            }
+          | prune

--- a/ecs/v9.5.0/wiz/wiz-cloud-configuration-findings.yaml
+++ b/ecs/v9.5.0/wiz/wiz-cloud-configuration-findings.yaml
@@ -1,0 +1,106 @@
+name: "Wiz Cloud Configuration Findings to ECS v9.5.0"
+description: "Maps Wiz Cloud Configuration Findings records into Elastic Common Schema (ECS) v9.5.0, populating event categorization, rule.*, cloud.*, host.*, and related.* field groups."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "wiz-cloud-configuration-findings"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "wiz"
+  - "cloud-configuration-findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Wiz Cloud Configuration Findings -> ECS v9.5.0 (nested)
+          # event.kind=alert, event.category=[configuration], event.type=[info]
+          # One jq pass; single end-of-pipeline prune.
+          # ---------------------------------------------------------------
+          def to_iso($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then ($ts | todateiso8601)
+            else $ts
+            end;
+
+          . as $r
+          | ($r.resource // {}) as $res
+          | ($r.rule // {}) as $rule
+          | (($r.securitySubCategories // [])[0]) as $ssc
+          | {
+              "@timestamp": (to_iso($r.firstSeenAt // $r.analyzedAt)),
+              "ecs": { "version": "9.5.0" },
+
+              "event": {
+                "kind": "alert",
+                "category": [ "configuration" ],
+                "type": [ "info" ],
+                "outcome": (
+                  { "PASS": "success", "FAIL": "failure" }[($r.result // "") | ascii_upcase] // "unknown"
+                ),
+                "id": ($r.id // null),
+                "provider": "wiz-cloud-configuration-findings",
+                "module": "wiz",
+                "dataset": "wiz.cloud_configuration_findings",
+                "severity": (
+                  { "INFORMATIONAL": 1, "LOW": 21, "MEDIUM": 47, "HIGH": 73, "CRITICAL": 99 }[($r.severity // "") | ascii_upcase] // 0
+                ),
+                "created": (to_iso($r.firstSeenAt)),
+                "reason": ($rule.name // null),
+                "action": ($r.status // null)
+              },
+
+              "message": ($rule.name // null),
+
+              "rule": {
+                "id": ($rule.id // null),
+                "name": ($rule.name // null),
+                "description": ($rule.description // null),
+                "reference": ($rule.shortId // null),
+                "ruleset": ($ssc.category.framework.name // null),
+                "category": ($ssc.category.name // null),
+                "author": [ "Wiz" ]
+              },
+
+              "cloud": {
+                "provider": (($res.cloudPlatform // null) | if . == null then null else ascii_downcase end),
+                "region": ($res.region // null),
+                "account": {
+                  "id": ($res.subscription.externalId // null),
+                  "name": ($res.subscription.name // null)
+                }
+              },
+
+              "host": {
+                "id": ($res.id // null),
+                "name": ($res.name // null),
+                "type": ($res.nativeType // $res.type // null)
+              },
+
+              "observer": {
+                "vendor": "Wiz",
+                "product": "Wiz",
+                "type": "cspm"
+              },
+
+              "tags": (
+                [ ($r.severity // empty), ($r.status // empty) ]
+                | map(select(. != null)) | if length == 0 then null else . end
+              ),
+
+              "related": {
+                "hosts": (
+                  [ ($res.name // empty) ] | map(select(. != null)) | unique
+                  | if length == 0 then null else . end
+                )
+              }
+            }
+          | walk(
+              if type == "object" then
+                with_entries(select(.value != null and .value != {} and .value != []))
+              else . end
+            )

--- a/ecs/v9.5.0/wiz/wiz-vulnerabilities.yaml
+++ b/ecs/v9.5.0/wiz/wiz-vulnerabilities.yaml
@@ -1,0 +1,134 @@
+name: "Wiz Vulnerabilities to ECS v9.5.0"
+description: "Normalizes individual Wiz vulnerability finding records into Elastic Common Schema (ECS) v9.5.0 (event, vulnerability, package, cloud, host, file, related), modeling each finding as an event.kind alert in the vulnerability category."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "wiz-vulnerabilities"
+tags:
+  - "v9.5.0"
+  - "ecs"
+  - "wiz"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # =================================================================
+          # Wiz Vulnerabilities  ->  ECS v9.5.0
+          # Input: ONE Wiz vulnerability finding record per invocation.
+          # A detected vulnerability is a finding, so event.kind=alert,
+          # event.category=[vulnerability], event.type=[info] (the only
+          # ECS-legal type for the vulnerability category).
+          # =================================================================
+
+          # An ES `ip` field rejects a document if handed a hostname, so guard
+          # every value routed to an ip-typed field.
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          def to_iso($ts):
+            if $ts == null then null
+            elif ($ts | type) == "string" then $ts
+            else null end;
+
+          def prune:
+            walk(
+              if type == "object" then with_entries(select(.value != null and .value != {} and .value != []))
+              elif type == "array" then map(select(. != null))
+              else . end
+            );
+
+          . as $r
+          | ($r.vulnerableAsset // {}) as $a
+          | ($r.name // $r.Name) as $cve_id
+          | ($r.vendorSeverity // $r.VendorSeverity) as $vsev
+          | ($r.cloudPlatform // $a.cloudPlatform // $r.CloudPlatform) as $provider
+          | ($a.ipAddresses // $r.IpAddresses // []) as $ips
+          | {
+              ecs: { version: "9.5.0" },
+
+              "@timestamp": ($r.firstDetectedAt // $r.FirstDetected),
+
+              event: {
+                kind: "alert",
+                module: "wiz",
+                dataset: "wiz.vulnerabilities",
+                provider: "wiz",
+                id: ($r.id // $r.ID),
+                category: ["vulnerability"],
+                type: ["info"],
+                outcome: "unknown",
+                severity: (
+                  { "CRITICAL": 5, "Critical": 5, "HIGH": 4, "High": 4,
+                    "MEDIUM": 3, "Medium": 3, "LOW": 2, "Low": 2,
+                    "INFORMATIONAL": 1, "Informational": 1 }[$vsev] // 0
+                ),
+                url: ($r.portalUrl // $r.WizURL),
+                created: ($r.firstDetectedAt // $r.FirstDetected),
+                start: ($r.firstDetectedAt // $r.FirstDetected),
+                end: ($r.lastDetectedAt // $r.LastDetected),
+                reason: ($r.description // $r.Description)
+              },
+
+              vulnerability: {
+                id: $cve_id,
+                enumeration: (if ($cve_id | type) == "string" and ($cve_id | startswith("CVE-")) then "CVE" else null end),
+                description: ($r.CVEDescription // $r.description // $r.Description),
+                severity: $vsev,
+                status: ($r.status // $r.FindingStatus),
+                reference: ($r.link // $r.Link),
+                classification: "CVSS",
+                scanner: { vendor: "Wiz" },
+                score: {
+                  base: ($r.score // $r.Score),
+                  version: (if ($r.score // $r.Score) then "3.1" else null end)
+                }
+              },
+
+              package: {
+                name: ($r.detailedName // $r.DetailedName),
+                version: ($r.version // $r.Version),
+                path: ($r.locationPath // $r.LocationPath),
+                type: (if ($r.detectionMethod // $r.DetectionMethod) then ($r.detectionMethod // $r.DetectionMethod) else null end)
+              },
+
+              file: {
+                path: ($r.locationPath // $r.LocationPath)
+              },
+
+              host: {
+                id: ($a.id // $r.AssetID),
+                name: ($a.name // $r.AssetName),
+                os: { full: ($a.operatingSystem // $r.OperatingSystem) },
+                ip: ([ $ips[] | select(is_ip(.)) ])
+              },
+
+              cloud: {
+                provider: (($provider // "") | ascii_downcase | if . == "" then null else . end),
+                region: ($a.region // $r.AssetRegion),
+                account: {
+                  id: ($a.subscriptionId // $r.SubscriptionId),
+                  name: ($a.subscriptionName // $r.SubscriptionName)
+                },
+                instance: {
+                  id: ($a.providerUniqueId // $r.ProviderUniqueId),
+                  name: ($a.name // $r.AssetName)
+                }
+              },
+
+              related: {
+                ip: ([ $ips[] | select(is_ip(.)) ] | unique),
+                hosts: ([ ($a.name // $r.AssetName) ] | map(select(. != null)) | unique)
+              },
+
+              tags: (
+                if $r.projects then $r.projects
+                elif $r.Projects then $r.Projects
+                else null end
+              )
+            }
+          | prune


### PR DESCRIPTION
Adds vendor→**ECS v9.5.0** nested jq transforms, authored with the `ecs-transform-builder` skill and validated with its static validator (each: `ERRORS: none`, with `event.category`→`event.type` pairings enforced). Batch 1 covers the same 30 inputs.

**Note:** This is **batch 1 of 2** (30 high-value, ground-truth + well-documented inputs spanning every category). The remaining ~258 FIT inputs are being authored from vendor documentation on the same validator-gated harness and will be pushed to this branch shortly. Every transform here passed its format's offline validator before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)