### PR TITLE
feat(cef): vendor→CEF transforms + shared serializer

### DIFF
--- a/cef/v0/alienvault/alienvault-otx-indicators.yaml
+++ b/cef/v0/alienvault/alienvault-otx-indicators.yaml
@@ -1,0 +1,68 @@
+name: "AlienVault OTX Indicators to CEF"
+description: "Maps AlienVault OTX IOC indicator records (enriched with parent-pulse threat context) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "alienvault-otx-indicators"
+tags:
+  - "v0"
+  - "cef"
+  - "alienvault"
+  - "otx-indicators"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AlienVault OTX Indicators -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (derived from the indicator role)
+          #   - time fields (rt/end): epoch-MILLISECONDS
+          #   - custom slots cs*/cn* ALWAYS paired with their *Label
+          # Input: ONE OTX indicator record with a nested `.pulse` object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z")
+                   | (if test("Z$") then . else . + "Z" end)
+                   | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.type // "indicator") as $itype
+          | ($r.pulse // {}) as $p
+          | ($r.role // "") as $role
+
+          # role -> CEF severity 0-10
+          | ( { "malware_hosting":8, "c2":9, "command_and_control":9,
+                "exploit_hosting":8, "phishing":7, "malware":8,
+                "scanning_host":5, "bruteforce":5 }[$role] // 5 ) as $sev
+
+          | { _cef: {
+              vendor: "AlienVault",
+              product: "OTX",
+              version: "",
+              signature_id: $itype,
+              name: ($p.name // $r.title // ("OTX " + $itype + " indicator")),
+              severity: $sev,
+              extension: ( {
+                rt:       to_epoch_ms($r.created),
+                end:      to_epoch_ms($r.expiration),
+                msg:      ($r.description // $r.content // $p.description),
+                externalId: ($r.id | tostring),
+                outcome:  (if ($r.is_active // 0) == 1 then "active" else "inactive" end),
+                # No CEF dictionary home for IOC value / pulse context:
+                # overflow to custom slots, each paired with its label.
+                cs1Label: "indicatorType",  cs1: $itype,
+                cs2Label: "indicatorValue", cs2: $r.indicator,
+                cs3Label: "pulseName",      cs3: $p.name,
+                cs4Label: "tlp",            cs4: (if ($p.tlp // "") == "" then null else ("TLP:" + ($p.tlp | ascii_upcase)) end),
+                cs5Label: "adversary",      cs5: (if ($p.adversary // "") == "" then null else $p.adversary end),
+                cs6Label: "role",           cs6: (if $role == "" then null else $role end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/atlassian/atlassian-jira-audit-logs.yaml
+++ b/cef/v0/atlassian/atlassian-jira-audit-logs.yaml
@@ -1,0 +1,66 @@
+name: "Atlassian Jira Audit Logs to CEF"
+description: "Maps Atlassian Jira audit log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "atlassian-jira-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "atlassian"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Atlassian Jira Audit Logs -> CEF intermediate (T1).
+          # Input: one Jira auditing REST record per invocation
+          #   (/rest/api/3/auditing/record). No escaping here — the shared
+          #   CEF Serializer (T2) owns all escaping. Values are final form:
+          #   severity 0-10, times epoch-ms, custom slots paired with labels.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (( $ts
+                    | sub("\\.[0-9]+"; "")
+                    | sub("([+-][0-9]{2}:?[0-9]{2}|Z)$"; "")
+                    | . + "Z"
+                    | fromdateiso8601 ) * 1000)
+            end;
+
+          . as $r
+          | ($r.objectItem // {}) as $obj
+          | { _cef: {
+              vendor: "Atlassian",
+              product: "Jira",
+              version: "",
+              # Low-cardinality event class: the audit category (e.g.
+              # "group management", "user management", "permissions").
+              signature_id: ($r.category // "audit"),
+              name: ($r.summary // "Jira audit event"),
+              # Audit records are completed administrative actions -> Low.
+              severity: 2,
+              extension: ( {
+                rt:      to_epoch_ms($r.created),
+                externalId: (if $r.id == null then null else ($r.id | tostring) end),
+                suser:   $r.authorKey,
+                suid:    $r.authorAccountId,
+                src:     (if ($r.remoteAddress | type) == "string" and ($r.remoteAddress | test("^[0-9A-Fa-f:.]+$")) then $r.remoteAddress else null end),
+                act:     $r.summary,
+                outcome: "SUCCESS",
+                msg:     $r.description,
+                # Target object of the audit action.
+                duser:   (if ($obj.typeName // "") == "USER" then $obj.name else null end),
+                # Overflow to custom slots (each WITH its label).
+                cs1Label: "objectType",   cs1: $obj.typeName,
+                cs2Label: "objectName",   cs2: $obj.name,
+                cs3Label: "eventSource",  cs3: $r.eventSource,
+                cs4Label: "changedValues",
+                cs4: (if ($r.changedValues // []) | length > 0 then ($r.changedValues | tojson) else null end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-guardduty.yaml
+++ b/cef/v0/aws/aws-guardduty.yaml
@@ -1,0 +1,88 @@
+name: "AWS GuardDuty Findings to CEF"
+description: "Maps Amazon GuardDuty finding records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+# author is ALWAYS "Monad" — never a person. You are a contributor.
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-guardduty"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "guardduty"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Amazon GuardDuty finding -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping. Emit FINAL-FORM values: severity int 0-10, times as
+          # epoch-MILLISECONDS, custom slots paired with their *Label.
+          # One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          # GuardDuty severity (float 0-8.9) -> CEF severity bucket (int 0-10)
+          def cef_sev($s):
+            if $s == null then 0
+            elif $s < 1 then 1
+            elif $s < 4 then 3
+            elif $s < 7 then 6
+            else 9 end;
+
+          . as $r
+          | ($r.service // {}) as $svc
+          | ($svc.action // {}) as $act
+          | ($act.networkConnectionAction // {}) as $nca
+          | ($nca.remoteIpDetails // {}) as $remote
+          | ($remote.geoLocation // {}) as $geo
+          | ($nca.localIpDetails // {}) as $local
+          | ($r.resource // {}) as $res
+          | (($res.instanceDetails // {})) as $inst
+          | ($nca.blocked == true) as $blocked
+          | { _cef: {
+              vendor: "AWS",
+              product: "Amazon GuardDuty",
+              version: ($r.schemaVersion // ""),
+              signature_id: $r.type,
+              name: $r.title,
+              severity: cef_sev($r.severity),
+              extension: ( {
+                rt:     to_epoch_ms($r.updatedAt // $r.createdAt),
+                start:  to_epoch_ms($svc.eventFirstSeen),
+                end:    to_epoch_ms($svc.eventLastSeen),
+                msg:    $r.description,
+                reason: $r.title,
+                externalId: $r.id,
+                cat:    "intrusion_detection",
+                act:    ($act.actionType),
+                outcome: (if $blocked then "BLOCKED" else "DETECTED" end),
+                proto:  $nca.protocol,
+                deviceDirection: (if ($nca.connectionDirection == "OUTBOUND") then 1 else 0 end),
+                src:    ($remote.ipAddressV4),
+                spt:    (($nca.remotePortDetails // {}).port),
+                dst:    ($local.ipAddressV4),
+                dpt:    (($nca.localPortDetails // {}).port),
+                dvchost: ($inst.networkInterfaces[0] // {}).privateDnsName,
+                # counts / numeric custom slots (paired with labels)
+                cn1: $svc.count, cn1Label: "aggregateCount",
+                # string custom slots (paired with labels)
+                cs1: $r.accountId,        cs1Label: "awsAccountId",
+                cs2: $r.region,           cs2Label: "awsRegion",
+                cs3: $svc.detectorId,     cs3Label: "detectorId",
+                cs4: $inst.instanceId,    cs4Label: "instanceId",
+                cs5: (($remote.country // {}).countryName),  cs5Label: "sourceCountry",
+                cs6: (($remote.organization // {}).asnOrg),  cs6Label: "sourceAsnOrg",
+                # geo floats (paired with labels)
+                cfp1: $geo.lat, cfp1Label: "sourceLatitude",
+                cfp2: $geo.lon, cfp2Label: "sourceLongitude"
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-security-hub-findings.yaml
+++ b/cef/v0/aws/aws-security-hub-findings.yaml
@@ -1,0 +1,76 @@
+name: "AWS Security Hub Findings to CEF"
+description: "Maps AWS Security Hub findings (ASFF) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-security-hub-findings"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Security Hub finding (ASFF) -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns it.
+          # Final-form values: severity int 0-10; times epoch-MILLISECONDS;
+          # custom cs*/cn* slots always paired with their *Label.
+          # One jq pass; shallow null-drop on extension (no recursive walk).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          # ASFF Severity.Label -> CEF severity bucket (0-10)
+          def cef_sev($lbl):
+            { "INFORMATIONAL": 1, "LOW": 3, "MEDIUM": 5,
+              "HIGH": 8, "CRITICAL": 10 }[$lbl] // 0;
+
+          . as $r
+          | ($r.Severity // {}) as $sev
+          | ($r.Network // {}) as $net
+          | ($r.Resources // []) as $res
+          | { _cef: {
+              vendor: ($r.CompanyName // "AWS"),
+              product: ($r.ProductName // "Security Hub"),
+              version: ($r.SchemaVersion // ""),
+              # Stable, low-cardinality finding type from the ASFF taxonomy.
+              signature_id: (($r.Types // [])[0] // "aws-security-hub-finding"),
+              name: ($r.Title // "AWS Security Hub Finding"),
+              severity: cef_sev($sev.Label),
+              extension: ( {
+                rt:       to_epoch_ms($r.UpdatedAt // $r.CreatedAt),
+                start:    to_epoch_ms($r.FirstObservedAt),
+                end:      to_epoch_ms($r.LastObservedAt),
+                externalId: $r.Id,
+                msg:      $r.Description,
+                act:      (($r.Workflow // {}).Status),
+                outcome:  (($r.Compliance // {}).Status),
+                cat:      ($r.RecordState // "ACTIVE"),
+                dvc:      ($net.DestinationIpV4),
+                src:      ($net.SourceIpV4),
+                spt:      ($net.SourcePort),
+                dst:      ($net.DestinationIpV4),
+                dpt:      ($net.DestinationPort),
+                proto:    ($net.Protocol),
+                deviceDirection: (if ($net.Direction) == "IN" then 0
+                                  elif ($net.Direction) == "OUT" then 1 else null end),
+                # Dictionary has no home for these -> custom slots WITH labels.
+                cs1Label: "awsAccountId",  cs1: ($r.AwsAccountId),
+                cs2Label: "awsRegion",     cs2: ($r.Region),
+                cs3Label: "resourceId",    cs3: ($res[0].Id),
+                cs4Label: "findingType",   cs4: (($r.Types // []) | join(",") | if . == "" then null else . end),
+                cs5Label: "remediation",   cs5: ($r.Remediation.Recommendation.Text),
+                cs6Label: "sourceUrl",     cs6: ($r.SourceUrl),
+                cn1Label: "normalizedSeverity", cn1: ($sev.Normalized),
+                cn2Label: "confidence",          cn2: ($r.Confidence)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/cloudtrail.yaml
+++ b/cef/v0/aws/cloudtrail.yaml
@@ -1,0 +1,99 @@
+name: "AWS CloudTrail to CEF"
+description: "Maps individual AWS CloudTrail event records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudtrail"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "cloudtrail"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS CloudTrail -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping/header assembly. Emit FINAL-FORM values:
+          #   - severity: integer 0-10
+          #   - time fields (rt): epoch-MILLISECONDS
+          #   - custom slots cs*/cn* ALWAYS paired with their *Label
+          # One jq pass; drop nulls with a shallow with_entries (no walk).
+          # ---------------------------------------------------------------
+
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          def real_name($s):
+            if ($s | type) == "string" and $s != "HIDDEN_DUE_TO_SECURITY_REASONS"
+            then $s else null end;
+
+          def g($o; $k): if ($o | type) == "object" then $o[$k] else null end;
+
+          def session_name($p):
+            if ($p | type) == "string" and ($p | test(":"))
+            then ($p | sub("^[^:]*:"; "")) else null end;
+
+          . as $r
+          | ( $r.userIdentity // {} ) as $ui
+          | ( $ui.sessionContext // {} ) as $sc
+
+          | ( ($r.errorCode // null) != null ) as $is_failure
+
+          # Resolve the acting human (falls back to the role name).
+          | ( g($ui.onBehalfOf; "userId") ) as $idc_user_id
+          | ( g($sc; "sourceIdentity")
+              // real_name($ui.userName)
+              // ( if $idc_user_id != null then session_name($ui.principalId) else null end )
+              // real_name($sc.sessionIssuer.userName) ) as $actor_name
+
+          # Severity: failed calls and root-user activity rank higher than a
+          # routine successful API call.
+          | ( if $is_failure then 7
+              elif ($ui.type // "") == "Root" then 8
+              elif ($r.readOnly // false) == true then 2
+              else 4 end ) as $severity
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "CloudTrail",
+              version: ($r.eventVersion // ""),
+              signature_id: $r.eventName,
+              name: (($r.eventName // "API call") + " on " + ($r.eventSource // "aws")),
+              severity: $severity,
+              extension: ( {
+                rt:        to_epoch_ms($r.eventTime),
+                externalId: $r.eventID,
+                act:       $r.eventName,
+                suser:     $actor_name,
+                suid:      ($idc_user_id // $ui.principalId),
+                src:       ( if is_ip($r.sourceIPAddress) then $r.sourceIPAddress else null end ),
+                dhost:     ( if is_ip($r.sourceIPAddress) then null else $r.sourceIPAddress end ),
+                requestClientApplication: $r.userAgent,
+                outcome:   ( if $is_failure then "FAILURE" else "SUCCESS" end ),
+                reason:    $r.errorCode,
+                msg:       $r.errorMessage,
+                dvchost:   ( g($r.tlsDetails; "clientProvidedHostHeader") ),
+                # Custom slots (each paired with its *Label).
+                cs1Label: "awsRegion",       cs1: $r.awsRegion,
+                cs2Label: "recipientAccountId", cs2: ($r.recipientAccountId // $ui.accountId),
+                cs3Label: "userIdentityType", cs3: $ui.type,
+                cs4Label: "userIdentityArn",  cs4: $ui.arn,
+                cs5Label: "accessKeyId",      cs5: $ui.accessKeyId,
+                cs6Label: "eventType",        cs6: $r.eventType,
+                cs7Label: "eventSource",      cs7: $r.eventSource,
+                cn1Label: "readOnly",         cn1: ( if ($r.readOnly // false) then 1 else 0 end )
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/box/box-events.yaml
+++ b/cef/v0/box/box-events.yaml
@@ -1,0 +1,66 @@
+name: "Box Enterprise Events to CEF"
+description: "Maps Box Enterprise Events into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "box-events"
+tags:
+  - "v0"
+  - "cef"
+  - "box"
+  - "events"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # Box Enterprise Events -> CEF intermediate (T1). No escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. One jq pass,
+          # per-record only; shallow null-drop on the extension object.
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+"; "") | sub("([+-][0-9]{2}:[0-9]{2}|Z)$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.event_type) as $et
+          # severity bucket 0-10: risky events higher, normal file ops informational
+          | (if ($et | type) != "string" then 3
+             elif ($et | test("FILE_MARKED_MALICIOUS|SHIELD_|DEVICE_TRUST_CHECK_FAILED")) then 8
+             elif ($et | test("FAILED_|ERROR|REJECT|DECLINE|DENIED")) then 6
+             elif ($et | test("DELETE|TRASH|PURGE")) then 4
+             else 3 end) as $sev
+          | (if ($et | type) == "string" and ($et | test("FAILED_|ERROR|REJECT|DECLINE|DENIED")) then "FAILURE" else "SUCCESS" end) as $outcome
+          | {
+              _cef: {
+                vendor: "Box",
+                product: "Box Enterprise Events",
+                version: "",
+                signature_id: ($et // "UNKNOWN"),
+                name: ( "Box "
+                        + ($et // "event")
+                        + (if ($r.source.item_name // $r.source.name // "") != "" then " on " + ($r.source.item_name // $r.source.name) else "" end) ),
+                severity: $sev,
+                extension: ( {
+                    rt: to_epoch_ms($r.created_at),
+                    suser: ($r.created_by.login // $r.created_by.name),
+                    suid: ($r.created_by.id | tostring?),
+                    src: $r.ip_address,
+                    act: $et,
+                    outcome: $outcome,
+                    fname: ($r.source.item_name // $r.source.name),
+                    fsize: ($r.additional_details.size),
+                    cs1Label: "boxItemId",
+                    cs1: (($r.source.item_id // $r.source.id) | tostring?),
+                    cs2Label: "boxSessionId",
+                    cs2: $r.session_id,
+                    cs3Label: "boxService",
+                    cs3: ($r.additional_details.service_name),
+                    cs4Label: "boxEventId",
+                    cs4: $r.event_id
+                  } | with_entries(select(.value != null and .value != "")) )
+              }
+            }

--- a/cef/v0/crowdstrike/crowdstrike-device-details.yaml
+++ b/cef/v0/crowdstrike/crowdstrike-device-details.yaml
@@ -1,0 +1,70 @@
+name: "CrowdStrike Device Details to CEF"
+description: "Maps CrowdStrike Falcon device details records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-device-details"
+tags:
+  - "v0"
+  - "cef"
+  - "crowdstrike"
+  - "device"
+  - "inventory"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # CrowdStrike Falcon device details -> CEF intermediate (T1).
+          # Emits FINAL-FORM values; does NO escaping (the shared CEF
+          # Serializer T2 owns all escaping/header assembly).
+          #   - severity: integer 0-10 (device inventory is informational)
+          #   - rt: epoch-MILLISECONDS
+          #   - custom slots cs*/cn* always paired with their *Label
+          # One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | ascii_upcase | gsub("\\.[0-9]+Z?$"; "") | gsub("Z$"; "")
+                   | strptime("%Y-%m-%dT%H:%M:%S") | mktime) * 1000)
+            end;
+
+          . as $r
+          | { _cef: {
+              vendor: "CrowdStrike",
+              product: "Falcon",
+              version: ($r.agent_version // ""),
+              signature_id: "crowdstrike:device-details",
+              name: ("Device inventory: " + ($r.hostname // "unknown host")),
+              # Inventory is informational; a sensor in Reduced Functionality
+              # Mode is a degraded/notable state, so bump the severity.
+              severity: ( if ($r.reduced_functionality_mode // "no") != "no" then 4 else 2 end ),
+              extension: ( {
+                rt:       to_epoch_ms($r.agent_local_time),
+                start:    to_epoch_ms($r.first_seen),
+                end:      to_epoch_ms($r.last_seen),
+                dvchost:  $r.hostname,
+                dvc:      $r.local_ip,
+                dvcmac:   $r.mac_address,
+                externalId: $r.device_id,
+                deviceExternalId: $r.device_id,
+                dhost:    $r.hostname,
+                dntdom:   $r.machine_domain,
+                deviceInboundInterface: $r.interface_name,
+                sourceServiceName: "Falcon",
+                outcome:  $r.status,
+                # OS / platform
+                cs1Label: "osVersion",    cs1: $r.os_version,
+                cs2Label: "osBuild",      cs2: $r.os_build,
+                cs3Label: "platform",     cs3: $r.platform_name,
+                cs4Label: "serialNumber", cs4: $r.serial_number,
+                cs5Label: "cloudProvider", cs5: $r.service_provider,
+                cs6Label: "productType",  cs6: $r.product_type_desc,
+                # numeric custom
+                cn1Label: "agentLoadFlags", cn1: ($r.agent_load_flags | if . == null then null else tonumber end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/crowdstrike/crowdstrike-event-stream.yaml
+++ b/cef/v0/crowdstrike/crowdstrike-event-stream.yaml
@@ -1,0 +1,68 @@
+name: "CrowdStrike Event Stream Detections to CEF"
+description: "Maps CrowdStrike Falcon Event Stream DetectionSummaryEvent records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-event-stream"
+tags:
+  - "v0"
+  - "cef"
+  - "crowdstrike"
+  - "detection"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # CrowdStrike Falcon Event Stream (DetectionSummaryEvent) -> CEF (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns it.
+          # Final-form values only: severity int 0-10; times epoch-MILLIS;
+          # custom cs*/cn* slots paired with their *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1000000000000 then $ts else ($ts * 1000) end | floor)
+            else null end;
+
+          . as $r
+          | ($r.event // {}) as $e
+          | ($r.metadata // {}) as $m
+          # CrowdStrike Severity 1..5 -> CEF severity 0..10 (x2 clamp)
+          | (($e.Severity // 0) * 2) as $sev
+          | { _cef: {
+              vendor: "CrowdStrike",
+              product: "Falcon",
+              version: ($m.version // ""),
+              signature_id: ($m.eventType // "DetectionSummaryEvent"),
+              name: ($e.DetectName // "CrowdStrike Detection"),
+              severity: (if $sev > 10 then 10 elif $sev < 0 then 0 else $sev end),
+              extension: ( {
+                rt:       to_epoch_ms($m.eventCreationTime),
+                start:    to_epoch_ms($e.ProcessStartTime),
+                dhost:    $e.ComputerName,
+                dvchost:  $e.ComputerName,
+                duser:    $e.UserName,
+                src:      $e.LocalIP,
+                smac:     $e.MACAddress,
+                dntdom:   $e.MachineDomain,
+                msg:      $e.DetectDescription,
+                act:      $e.PatternDispositionDescription,
+                outcome:  (if ($e.PatternDispositionValue // 0) > 0 then "Prevented" else "Detected" end),
+                fname:    $e.FileName,
+                filePath: $e.FilePath,
+                fileHash: $e.SHA256String,
+                dproc:    $e.CommandLine,
+                dpid:     $e.ProcessId,
+                request:  $e.FalconHostLink,
+                cs1Label: "Tactic",          cs1: $e.Tactic,
+                cs2Label: "Technique",       cs2: $e.Technique,
+                cs3Label: "Objective",       cs3: $e.Objective,
+                cs4Label: "SeverityName",    cs4: $e.SeverityName,
+                cs5Label: "MD5",             cs5: $e.MD5String,
+                cs6Label: "DetectId",        cs6: $e.DetectId,
+                cn1Label: "PatternDisposition", cn1: $e.PatternDispositionValue
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/crowdstrike/crowdstrike-falcon-data-replicator.yaml
+++ b/cef/v0/crowdstrike/crowdstrike-falcon-data-replicator.yaml
@@ -1,0 +1,70 @@
+name: "CrowdStrike Falcon Data Replicator to CEF"
+description: "Maps a CrowdStrike Falcon Data Replicator (FDR) ProcessRollup2 endpoint telemetry record into the normalized CEF intermediate (_cef); the shared CEF serializer renders the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-falcon-data-replicator"
+tags:
+  - "v0"
+  - "cef"
+  - "crowdstrike"
+  - "falcon-data-replicator"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # CEF T1 mapping — CrowdStrike Falcon Data Replicator ProcessRollup2
+          # Emits the {_cef:{...}} intermediate. No escaping here; the shared
+          # CEF serializer (T2) owns escaping + header assembly.
+          # ---------------------------------------------------------------
+
+          def basename($p):
+            if $p == null or $p == "" then null
+            else ($p | gsub("\\\\"; "/") | split("/") | last)
+            end;
+
+          # FDR .timestamp is already epoch milliseconds (string) -> number.
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            else ($ts | tonumber | floor)
+            end;
+
+          . as $r
+          | {
+              _cef: {
+                vendor: "CrowdStrike",
+                product: "Falcon Data Replicator",
+                version: "",
+                signature_id: ($r.event_simpleName // "FDR"),
+                name: ("Process execution (" + ($r.event_simpleName // "ProcessRollup2") + ")"),
+                severity: 3,
+                extension: (
+                  {
+                    rt: to_epoch_ms($r.timestamp),
+                    dhost: $r.ComputerName,
+                    dvchost: $r.ComputerName,
+                    suser: $r.UserName,
+                    src: $r.aip,
+                    dproc: basename($r.ImageFileName),
+                    dpid: (if $r.RawProcessId != null then ($r.RawProcessId | tonumber) else null end),
+                    sproc: $r.ParentBaseFileName,
+                    filePath: $r.ImageFileName,
+                    fileHash: $r.SHA256HashData,
+                    act: $r.event_simpleName,
+                    cs1Label: "AgentId",
+                    cs1: $r.aid,
+                    cs2Label: "CustomerId",
+                    cs2: $r.cid,
+                    cs3Label: "CommandLine",
+                    cs3: $r.CommandLine,
+                    cs4Label: "FalconProcessId",
+                    cs4: $r.TargetProcessId
+                  }
+                  | with_entries(select(.value != null and .value != ""))
+                )
+              }
+            }

--- a/cef/v0/crowdstrike/crowdstrike-vulnerabilities.yaml
+++ b/cef/v0/crowdstrike/crowdstrike-vulnerabilities.yaml
@@ -1,0 +1,62 @@
+name: "CrowdStrike Vulnerabilities to CEF"
+description: "Maps CrowdStrike Spotlight vulnerability findings into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+# author is ALWAYS "Monad" — never a person. You are a contributor.
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "crowdstrike-vulnerabilities"
+tags:
+  - "v0"
+  - "cef"
+  - "crowdstrike"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # CrowdStrike Spotlight vulnerabilities -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (mapped from CVE severity bucket)
+          #   - rt: epoch-MILLISECONDS
+          #   - custom slots cs*/cn* ALWAYS paired with their *Label
+          # One jq pass, per-record; shallow null-drop on extension only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ( $r.cve // {} ) as $cve
+          | ( $r.host_info // {} ) as $h
+          | ( $r.remediation.entities // [] ) as $rem
+          | { _cef: {
+              vendor: "CrowdStrike",
+              product: "Falcon Spotlight",
+              version: "",
+              signature_id: ($r.vulnerability_id // "UNKNOWN"),
+              name: ("Vulnerability detected: " + ($r.vulnerability_id // "UNKNOWN")),
+              severity: ( { "CRITICAL": 10, "HIGH": 8, "MEDIUM": 5, "LOW": 3 }[$cve.severity] // 0 ),
+              extension: ( {
+                rt:       to_epoch_ms($r.created_timestamp),
+                end:      to_epoch_ms($r.updated_timestamp),
+                msg:      $cve.description,
+                dhost:    $h.hostname,
+                dvc:      $h.local_ip,
+                externalId: $r.aid,
+                dntdom:   $h.machine_domain,
+                cs1Label: "CVE",           cs1: ($r.vulnerability_id // ""),
+                cs2Label: "CVSSVector",    cs2: ($cve.vector // ""),
+                cn1Label: "CVSSBaseScore", cn1: ($cve.base_score // null),
+                cs3Label: "Status",        cs3: ($r.status // ""),
+                cs4Label: "Confidence",    cs4: ($r.confidence // ""),
+                cs5Label: "Remediation",   cs5: ( if ($rem | length) > 0 then ($rem | map(.action) | join("; ")) else "" end ),
+                cs6Label: "OS",            cs6: (($h.platform // "") + " " + ($h.os_version // "") | gsub("^\\s+|\\s+$"; ""))
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/duo-security/duo-security-auth-logs.yaml
+++ b/cef/v0/duo-security/duo-security-auth-logs.yaml
@@ -1,0 +1,62 @@
+name: "Duo Security Authentication Logs to CEF"
+description: "Maps Cisco Duo Security authentication log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "duo-security-auth-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "duo-security"
+  - "auth-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Duo Security authentication log -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # severity: integer 0-10; times epoch-MS; custom slots + *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+"; "") | gsub("\\+00:00$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.result // "" | ascii_downcase) as $result
+          | {
+              _cef: {
+                vendor: "Cisco",
+                product: "Duo Security",
+                version: "",
+                signature_id: ($r.event_type // "authentication"),
+                name: ("Duo authentication " + (if $result == "success" then "succeeded"
+                                                elif $result == "" then "event"
+                                                else ($result + " (" + ($r.reason // "unknown") + ")") end)),
+                severity: (if $result == "success" then 2
+                           elif $result == "fraud" then 9
+                           elif ($result == "denied") or ($result == "failure") or ($result == "error") then 6
+                           else 0 end),
+                extension: ( {
+                  rt:      to_epoch_ms($r.timestamp // $r.isotimestamp),
+                  suser:   ($r.user.name // $r.email),
+                  suid:    $r.user.key,
+                  src:     ($r.access_device.ip // null),
+                  dvc:     ($r.auth_device.ip // null),
+                  act:     ($r.event_type // null),
+                  outcome: (($r.result // null) | if . == null then null else ascii_upcase end),
+                  reason:  ($r.reason // null),
+                  requestClientApplication: ((($r.access_device.browser // "") + " " + ($r.access_device.browser_version // "")) | sub("^ +| +$"; "") | if . == "" then null else . end),
+                  cs1Label: "duoFactor",              cs1: ($r.factor // null),
+                  cs2Label: "application",            cs2: ($r.application.name // null),
+                  cs3Label: "txid",                   cs3: ($r.txid // null),
+                  cs4Label: "trustedEndpointStatus",  cs4: ($r.trusted_endpoint_status // null),
+                  cs5Label: "srcCountry",             cs5: ($r.access_device.location.country // null)
+                } | with_entries(select(.value != null and .value != "")) )
+              }
+            }

--- a/cef/v0/github/github-audit-logs.yaml
+++ b/cef/v0/github/github-audit-logs.yaml
@@ -1,0 +1,60 @@
+name: "GitHub Audit Logs to CEF"
+description: "Maps GitHub (Enterprise/Organization) audit log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "github-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "github"
+  - "audit-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # GitHub audit logs -> CEF intermediate (T1). No escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. Final-form
+          # values: severity int 0-10, times epoch-MILLISECONDS, custom
+          # slots paired with *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          . as $r
+          | def to_epoch_ms($ts):
+              if $ts == null then null
+              elif ($ts | type) == "number" then (if $ts > 1e12 then ($ts | floor) else (($ts * 1000) | floor) end)
+              else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+              end;
+
+          # operation_type -> coarse severity bucket (0-10).
+          ( { "remove": 6, "modify": 5, "create": 4, "transfer": 6,
+                "authentication": 3, "access": 2 }[$r.operation_type] // 3 ) as $sev
+
+          | { _cef: {
+              vendor: "GitHub",
+              product: "GitHub Audit Log",
+              version: "",
+              signature_id: $r.action,
+              name: (($r.actor // "?") + " " + ($r.action // "?")),
+              severity: $sev,
+              extension: ( {
+                rt:       to_epoch_ms($r.created_at // $r["@timestamp"]),
+                suser:    $r.actor,
+                suid:     (if $r.actor_id != null then ($r.actor_id | tostring) else null end),
+                src:      $r.actor_ip,
+                duser:    $r.user,
+                duid:     (if $r.user_id != null then ($r.user_id | tostring) else null end),
+                act:      $r.action,
+                outcome:  "SUCCESS",
+                requestClientApplication: $r.user_agent,
+                cs1Label: "org",            cs1:  $r.org,
+                cs2Label: "repository",     cs2:  ($r.repo // $r.repository),
+                cs3Label: "team",           cs3:  $r.team,
+                cs4Label: "operationType",  cs4:  $r.operation_type,
+                cs5Label: "actorCountry",   cs5:  $r.actor_location.country_code,
+                cs6Label: "documentId",     cs6:  $r._document_id
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/github/github-dependabot-alerts.yaml
+++ b/cef/v0/github/github-dependabot-alerts.yaml
@@ -1,0 +1,66 @@
+name: "GitHub Dependabot Alerts to CEF"
+description: "Maps GitHub Dependabot vulnerability alert records into the normalized {_cef:{...}} CEF intermediate (advisory identifiers, CVSS score, affected package, repository). Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "github-dependabot-alerts"
+tags:
+  - "v0"
+  - "cef"
+  - "github"
+  - "dependabot"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # GitHub Dependabot Alert -> CEF intermediate (T1).
+          # NO escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Final-form values: severity int 0-10; times epoch-MS; custom
+          # slots paired with their *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.security_advisory // {}) as $adv
+          | ($r.security_vulnerability // {}) as $sv
+          | ($r.dependency // {}) as $dep
+          | (($dep.package // $sv.package // $adv.vulnerabilities[0].package) // {}) as $pkg
+          | ($adv.severity // $sv.severity // "") as $sev
+
+          | { _cef: {
+              vendor: "GitHub",
+              product: "Dependabot",
+              version: "",
+              signature_id: ("dependabot.alert." + ($r.state // "unknown")),
+              name: ($adv.summary // ("Dependabot alert " + ($r.number | tostring))),
+              # GitHub advisory severity -> CEF 0-10 bucket
+              severity: ( { "low": 3, "medium": 6, "high": 8, "critical": 10 }[$sev] // 0 ),
+              extension: ( {
+                rt:      to_epoch_ms($r.updated_at // $r.created_at),
+                start:   to_epoch_ms($r.created_at),
+                msg:     ($adv.summary // $adv.description),
+                act:     $r.state,
+                outcome: (if $r.state == "fixed" then "SUCCESS"
+                          elif ($r.state == "dismissed" or $r.state == "auto_dismissed") then "SUPPRESSED"
+                          else "OPEN" end),
+                request: $r.html_url,
+                fname:   $dep.manifest_path,
+                reason:  $r.dismissed_reason,
+                cat:     $pkg.ecosystem,
+                cs1Label: "cveId",                   cs1: $adv.cve_id,
+                cs2Label: "ghsaId",                  cs2: $adv.ghsa_id,
+                cs3Label: "vulnerablePackage",       cs3: $pkg.name,
+                cs4Label: "vulnerableVersionRange",  cs4: $sv.vulnerable_version_range,
+                cs5Label: "fixedInVersion",          cs5: $sv.first_patched_version.identifier,
+                cs6Label: "repository",              cs6: ($r.repository.full_name // $r.repository.name),
+                cfp1Label: "cvssBaseScore",          cfp1: $adv.cvss.score
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/google/google-cloud-logs.yaml
+++ b/cef/v0/google/google-cloud-logs.yaml
@@ -1,0 +1,60 @@
+name: "Google Cloud Audit Logs to CEF"
+description: "Maps Google Cloud (Cloud Audit) Log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "google-cloud-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "google"
+  - "gcp"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Google Cloud Audit Logs -> CEF intermediate (T1). No escaping.
+          # severity: int 0-10; times epoch-MS; custom slots paired w/ labels.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.protoPayload // {}) as $pp
+          | ($pp.requestMetadata // {}) as $rm
+          | (($r.resource // {}).labels // {}) as $lbl
+          | (($pp.status // {}).code // 0) as $status_code
+          | { _cef: {
+              vendor: "Google",
+              product: "Google Cloud Platform",
+              version: "",
+              signature_id: ($pp.methodName // "gcp.audit.event"),
+              name: (($pp.methodName // "Google Cloud audit event") + " on " + ($pp.resourceName // "")),
+              severity: (
+                { "DEFAULT": 2, "DEBUG": 2, "INFO": 2, "NOTICE": 2,
+                  "WARNING": 5, "ERROR": 7, "CRITICAL": 8, "ALERT": 8,
+                  "EMERGENCY": 10 }[$r.severity] // 0
+              ),
+              extension: ( {
+                rt:      to_epoch_ms($r.timestamp),
+                suser:   ($pp.authenticationInfo // {}).principalEmail,
+                src:     $rm.callerIp,
+                act:     $pp.methodName,
+                outcome: (if $status_code == 0 then "SUCCESS" else "FAILURE" end),
+                requestClientApplication: $rm.callerSuppliedUserAgent,
+                deviceExternalId: $r.insertId,
+                cs1Label: "projectId",   cs1: $lbl.project_id,
+                cs2Label: "resourceName", cs2: $pp.resourceName,
+                cs3Label: "serviceName",  cs3: $pp.serviceName,
+                cs4Label: "logName",      cs4: $r.logName,
+                cn1Label: "statusCode",   cn1: ($status_code | tostring)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/google/google-workspace-login-activity.yaml
+++ b/cef/v0/google/google-workspace-login-activity.yaml
@@ -1,0 +1,86 @@
+name: "Google Workspace Login Activity to CEF"
+description: "Maps Google Workspace (Admin SDK Reports API) login activity records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "google-workspace-login-activity"
+tags:
+  - "v0"
+  - "cef"
+  - "google"
+  - "login"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Google Workspace login activity -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns it.
+          # Emit FINAL-FORM values: severity int 0-10, times epoch-MS,
+          # custom slots paired with their *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.events[0] // {}) as $ev
+          | ($ev.parameters // []) as $params
+          | ($ev.name // "") as $ename
+          | def param($n): ($params | map(select(.name == $n)) | first);
+            def pstr($n): (param($n) | if . == null then null
+                           else (.value // ((.multiValue // []) | join(","))) end);
+            def pbool($n): (param($n) | if . == null then null else .boolValue end);
+            ($r.actor.email) as $email
+
+          # severity bucket 0-10
+          | ( if ($ename | startswith("suspicious")) or (pbool("is_suspicious") == true) then 8
+              elif ($ename | startswith("login_failure")) then 6
+              elif ($ename | startswith("logout")) then 2
+              else 3 end ) as $sev
+
+          # outcome
+          | ( if $ename == "login_success" then "SUCCESS"
+              elif ($ename | startswith("login_failure") or startswith("suspicious")) then "FAILURE"
+              else "UNKNOWN" end ) as $outcome
+
+          | { _cef: {
+              vendor: "Google",
+              product: "Google Workspace Login",
+              version: "",
+              signature_id: $ename,
+              name: ( { "login_success": "User login succeeded",
+                        "login_failure": "User login failed",
+                        "logout": "User logout",
+                        "suspicious_login": "Suspicious login blocked" }[$ename]
+                      // $ename ),
+              severity: $sev,
+              extension: ( {
+                rt:      to_epoch_ms($r.id.time),
+                suser:   $email,
+                suid:    ($r.actor.profileId // null),
+                duser:   (pstr("affected_email_address")),
+                src:     ($r.ipAddress // null),
+                dhost:   "accounts.google.com",
+                act:     $ename,
+                outcome: $outcome,
+                externalId: ($r.id.uniqueQualifier | tostring),
+                cs1: (pstr("login_type")),
+                cs1Label: (if (pstr("login_type")) != null then "loginType" else null end),
+                cs2: (pstr("login_challenge_method")),
+                cs2Label: (if (pstr("login_challenge_method")) != null then "challengeMethod" else null end),
+                cs3: (pstr("login_challenge_status")),
+                cs3Label: (if (pstr("login_challenge_status")) != null then "loginChallengeStatus" else null end),
+                cs4: (pstr("login_failure_type")),
+                cs4Label: (if (pstr("login_failure_type")) != null then "loginFailureType" else null end),
+                cs5: ($r.id.customerId // null),
+                cs5Label: (if ($r.id.customerId // null) != null then "customerId" else null end),
+                cs6: (pbool("is_second_factor") | if . == null then null else tostring end),
+                cs6Label: (if (pbool("is_second_factor")) != null then "isSecondFactor" else null end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/jumpcloud/jumpcloud-events.yaml
+++ b/cef/v0/jumpcloud/jumpcloud-events.yaml
@@ -1,0 +1,60 @@
+name: "JumpCloud Directory Insights Events to CEF"
+description: "Maps JumpCloud Directory Insights event records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "jumpcloud-events"
+tags:
+  - "v0"
+  - "cef"
+  - "jumpcloud"
+  - "events"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # JumpCloud Directory Insights -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns it.
+          # Final-form values: severity int 0-10, times epoch-MS, custom
+          # slots paired with their *Label. One pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.initiated_by // {}) as $ib
+          | ($r.useragent // {}) as $ua
+          | ($r.username // $ib.username) as $uname
+          | (if $r.success == true then "SUCCESS"
+             elif $r.success == false then "FAILURE" else null end) as $outcome
+
+          | { _cef: {
+                vendor: "JumpCloud",
+                product: "Directory Insights",
+                version: "",
+                signature_id: ($r.event_type // "unknown"),
+                name: ($r.message // ($r.event_type // "JumpCloud Directory Insights event")),
+                # Failed authentication is elevated; success/info stays low.
+                severity: (if $r.success == false then 6 else 3 end),
+                extension: ( {
+                  rt:      to_epoch_ms($r.timestamp),
+                  suser:   $uname,
+                  suid:    (if $ib.type == "user" then $ib.id else null end),
+                  src:     $r.client_ip,
+                  act:     $r.event_type,
+                  outcome: $outcome,
+                  externalId: $r.id,
+                  requestClientApplication: ([ $ua.name, $ua.version ] | map(select(. != null)) | join(" ") | (if . == "" then null else . end)),
+                  cs1Label: "service",      cs1: $r.service,
+                  cs2Label: "organization", cs2: $r.organization,
+                  cs3Label: "mfa",          cs3: (if ($r.mfa | type) == "boolean" then ($r.mfa | tostring) else null end),
+                  cs4Label: "geoCountry",   cs4: ($r.geoip.country_code // null)
+                } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/microsoft/microsoft-azure-activity-logs.yaml
+++ b/cef/v0/microsoft/microsoft-azure-activity-logs.yaml
@@ -1,0 +1,70 @@
+name: "Microsoft Azure Activity Logs to CEF"
+description: "Maps Microsoft Azure Activity Log records (control-plane management operations) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "microsoft-azure-activity-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "microsoft"
+  - "azure-activity-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Microsoft Azure Activity Log -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Final-form values: severity int 0-10; times epoch-MS; cs* slots
+          # paired with *Label. One jq pass; shallow null-drop on extension.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          # operationName / resultType may arrive as {value, localizedValue}.
+          def strv($f):
+            if ($f | type) == "object" then ($f.value // $f.localizedValue)
+            else $f end;
+
+          . as $r
+          | ( $r.identity.claims // {} ) as $claims
+          | ( strv($r.operationName) // "" ) as $op
+          | ( strv($r.resultType) // $r.status // "" ) as $result
+          | ( $r.caller
+              // $claims["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"]
+              // $claims["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"] ) as $caller
+          | ( $r.callerIpAddress // $claims.ipaddr ) as $caller_ip
+          | ( if ($result | ascii_downcase | startswith("succ")) then "SUCCESS"
+              elif ($result | ascii_downcase | startswith("fail")) then "FAILURE"
+              else "UNKNOWN" end ) as $outcome
+
+          | { _cef: {
+              vendor: "Microsoft",
+              product: "Azure Activity Log",
+              version: "",
+              signature_id: (if $op == "" then "Unknown" else $op end),
+              name: (if $op == "" then "Azure control-plane activity" else $op end),
+              # Azure level -> CEF severity bucket (0-10).
+              severity: ( { "Informational": 2, "Warning": 5, "Error": 7, "Critical": 9 }[$r.level] // 0 ),
+              extension: ( {
+                rt:          to_epoch_ms($r.time // $r.eventTimestamp),
+                suser:       $caller,
+                src:         $caller_ip,
+                act:         $op,
+                outcome:     $outcome,
+                externalId:  $r.correlationId,
+                deviceExternalId: $r.subscriptionId,
+                msg:         ($r.properties.message // strv($r.resultSignature)),
+                cs1Label: "category",       cs1: $r.category,
+                cs2Label: "resourceId",     cs2: $r.resourceId,
+                cs3Label: "tenantId",       cs3: $r.tenantId,
+                cs4Label: "eventDataId",    cs4: $r.eventDataId
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/microsoft/microsoft-entra-id.yaml
+++ b/cef/v0/microsoft/microsoft-entra-id.yaml
@@ -1,0 +1,77 @@
+name: "Microsoft Entra ID Sign-in Logs to CEF"
+description: "Maps Microsoft Entra ID (Azure AD) sign-in log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "microsoft-entra-id"
+tags:
+  - "v0"
+  - "cef"
+  - "microsoft"
+  - "entra-id"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Microsoft Entra ID sign-in logs -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values: severity int 0-10, times as
+          # epoch-MILLISECONDS, custom cs*/cn* slots paired with *Label.
+          # One jq pass, per-record only; shallow null-drop on extension.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ( $r.status // {} ) as $st
+          | ( $r.deviceDetail // {} ) as $dd
+          | ( $r.location // {} ) as $loc
+          | ( ($st.errorCode // 0) == 0 ) as $ok
+          | ( $r.riskLevelDuringSignIn // $r.riskLevelAggregated // "none" ) as $risk
+          | { _cef: {
+              vendor: "Microsoft",
+              product: "Microsoft Entra ID",
+              version: "",
+              # Low-cardinality signature: sign-in success vs failure.
+              signature_id: ( if $ok then "signin.success" else "signin.failure" end ),
+              name: ( if $ok then "Entra ID sign-in succeeded" else "Entra ID sign-in failed" end ),
+              # Success is informational (2); failure is elevated, and a
+              # medium/high risk sign-in is escalated further.
+              severity: (
+                if ($ok | not) then 8
+                elif ($risk == "high") then 8
+                elif ($risk == "medium") then 5
+                else 2 end
+              ),
+              extension: ( {
+                rt:       to_epoch_ms($r.createdDateTime),
+                suser:    $r.userPrincipalName,
+                suid:     $r.userId,
+                src:      $r.ipAddress,
+                act:      "user-signin",
+                outcome:  ( if $ok then "SUCCESS" else "FAILURE" end ),
+                reason:   ($st.failureReason // $st.additionalDetails),
+                app:      $r.clientAppUsed,
+                dhost:    $dd.displayName,
+                deviceExternalId: $dd.deviceId,
+                requestClientApplication: $dd.browser,
+                externalId: $r.id,
+                # Custom slots (each paired with its *Label):
+                cs1Label: "resource",        cs1: $r.resourceDisplayName,
+                cs2Label: "appDisplayName",  cs2: $r.appDisplayName,
+                cs3Label: "conditionalAccessStatus", cs3: $r.conditionalAccessStatus,
+                cs4Label: "riskLevel",       cs4: $risk,
+                cs5Label: "authRequirement", cs5: $r.authenticationRequirement,
+                cs6Label: "correlationId",   cs6: $r.correlationId,
+                cn1Label: "errorCode",       cn1: ($st.errorCode // 0),
+                cfp1Label: "geoLatitude",    cfp1: ($loc.geoCoordinates.latitude),
+                cfp2Label: "geoLongitude",   cfp2: ($loc.geoCoordinates.longitude)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/monad/monad-logs.yaml
+++ b/cef/v0/monad/monad-logs.yaml
@@ -1,0 +1,62 @@
+name: "Monad Organization Logs to CEF"
+description: "Maps Monad Organization Logs (monad-logs) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "monad-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "monad"
+  - "organization"
+  - "logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # Monad Organization Logs -> CEF intermediate (T1). No escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. Emit FINAL-FORM values:
+          #   severity: integer 0-10; time fields: epoch-MILLISECONDS;
+          #   custom slots cs*/cn* always paired with their *Label.
+          . as $r
+          | def to_epoch_ms($ts):
+              if $ts == null then null
+              elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+              else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+              end;
+            ($r.status | tonumber) as $status
+          | {
+              _cef: {
+                vendor: "Monad",
+                product: "Monad Organization Logs",
+                version: ($r.log_version // ""),
+                signature_id: $r.method,
+                name: ("Monad API " + $r.method + " " + $r.resource),
+                severity: (
+                  if   $status >= 500 then 8
+                  elif $status >= 400 then 5
+                  else 2
+                  end
+                ),
+                extension: ({
+                  rt: to_epoch_ms($r.timestamp),
+                  suser: $r.user_email,
+                  src: $r.client_ip,
+                  requestMethod: $r.method,
+                  request: $r.resource,
+                  act: $r.method,
+                  outcome: (if $status >= 200 and $status < 400 then "SUCCESS" else "FAILURE" end),
+                  cn1: $status,
+                  cn1Label: "httpStatusCode",
+                  cs1: $r.log_version,
+                  cs1Label: "logVersion",
+                  cs2: $r.additional_info,
+                  cs2Label: "additionalInfo",
+                  cs3: $r.id,
+                  cs3Label: "requestId"
+                } | with_entries(select(.value != null and .value != "")))
+              }
+            }

--- a/cef/v0/nist/nist-cve.yaml
+++ b/cef/v0/nist/nist-cve.yaml
@@ -1,0 +1,82 @@
+name: "NIST NVD CVE to CEF"
+description: "Maps NIST NVD CVE records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "nist-cve"
+tags:
+  - "v0"
+  - "cef"
+  - "nist"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # NIST NVD CVE -> CEF intermediate (T1). No escaping here — the
+          # shared CEF Serializer (T2) owns all escaping. Emit FINAL-FORM:
+          #   - severity: integer 0-10 (CVSS base score maps directly)
+          #   - time fields (rt): epoch-MILLISECONDS
+          #   - custom slots cs*/cn* ALWAYS paired with their *Label
+          # One jq pass; shallow null-drop on extension (no recursive walk).
+          # Input: one NVD CVE record ({cve:{...}}) per invocation.
+          # ---------------------------------------------------------------
+
+          # NVD timestamps lack a zone (e.g. "2024-08-13T18:15:10.017");
+          # strip the fraction, force Z, then to epoch-ms.
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          # CVSS baseSeverity string -> CEF severity bucket (fallback when no
+          # numeric base score is present).
+          def sev_bucket($s):
+            ($s // "" | ascii_downcase) as $x |
+            if   $x == "none"     then 0
+            elif $x == "low"      then 3
+            elif $x == "medium"   then 5
+            elif $x == "high"     then 8
+            elif $x == "critical" then 10
+            else 0 end;
+
+          . as $r
+          | ($r.cve // $r) as $c
+          | (($c.descriptions // []) | (map(select(.lang == "en")) | .[0].value) // (.[0].value)) as $desc
+          | (($c.metrics.cvssMetricV31 // $c.metrics.cvssMetricV30 // $c.metrics.cvssMetricV2 // []) | .[0]) as $m
+          | ($m.cvssData // {}) as $cd
+          | ([ ($c.weaknesses // [])[].description[]? | select(.value | test("^CWE-")) | .value ] | unique | join(",")) as $cwe
+          | ([ ($c.references // [])[].url ] | unique) as $refs
+          | (if ($cwe | length) > 0 then $cwe else null end) as $cwe
+          | {
+              _cef: {
+                vendor: "NIST",
+                product: "National Vulnerability Database",
+                version: ($cd.version // ""),
+                signature_id: $c.id,
+                name: ($c.id + (if $desc != null then ": " + ($desc | .[0:180]) else "" end)),
+                severity: (if $cd.baseScore != null then ($cd.baseScore | floor) else sev_bucket($cd.baseSeverity) end),
+                extension: ( {
+                  rt:      to_epoch_ms($c.published),
+                  end:     to_epoch_ms($c.lastModified),
+                  msg:     $desc,
+                  reason:  $cd.baseSeverity,
+                  request: ($refs | first),
+                  outcome: $c.vulnStatus,
+                  cs1Label: "CVE ID",         cs1: $c.id,
+                  cs2Label: "CWE",            cs2: $cwe,
+                  cs3Label: "CVSS Vector",    cs3: $cd.vectorString,
+                  cs4Label: "CVSS Version",   cs4: $cd.version,
+                  cs5Label: "Vuln Status",    cs5: $c.vulnStatus,
+                  cs6Label: "Source",         cs6: $c.sourceIdentifier,
+                  cn1Label: "CVSS Base Score",     cn1: $cd.baseScore,
+                  cn2Label: "Exploitability Score", cn2: $m.exploitabilityScore,
+                  cn3Label: "Impact Score",        cn3: $m.impactScore
+                } | with_entries(select(.value != null and .value != "")) )
+              }
+            }

--- a/cef/v0/okta/okta-systemlog.yaml
+++ b/cef/v0/okta/okta-systemlog.yaml
@@ -1,0 +1,62 @@
+name: "Okta System Log to CEF"
+description: "Maps Okta System Log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "okta-systemlog"
+tags:
+  - "v0"
+  - "cef"
+  - "okta"
+  - "systemlog"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Okta System Log -> CEF intermediate (T1). No escaping here — the
+          # shared CEF Serializer (T2) owns all escaping. Emit FINAL-FORM
+          # values: severity integer 0-10, times epoch-MILLISECONDS, custom
+          # cs* slots always paired with their *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $d
+          | ($d.actor // {}) as $actor
+          | ($d.client // {}) as $client
+          | ($client.geographicalContext // {}) as $geo
+          | ($d.outcome.result // "") as $result
+
+          | { _cef: {
+              vendor: "Okta",
+              product: "Okta System Log",
+              version: ($d.version // ""),
+              signature_id: ($d.eventType // "okta.system.event"),
+              name: ($d.displayMessage // $d.eventType // "Okta System Log Event"),
+              severity: ( { "DEBUG": 1, "INFO": 2, "WARN": 5, "ERROR": 8 }[$d.severity] // 0 ),
+              extension: ( {
+                rt:      to_epoch_ms($d.published),
+                suser:   $actor.alternateId,
+                suid:    $actor.id,
+                src:     $client.ipAddress,
+                act:     $d.eventType,
+                outcome: ( if $result == "" then null else ($result | ascii_upcase) end ),
+                request: $d.debugContext.debugData.requestUri,
+                requestClientApplication: $client.userAgent.rawUserAgent,
+                msg:     $d.displayMessage,
+                cs1Label: "sessionId",       cs1: $d.authenticationContext.externalSessionId,
+                cs2Label: "sourceCity",      cs2: $geo.city,
+                cs3Label: "legacyEventType", cs3: $d.legacyEventType,
+                cs4Label: "clientDevice",    cs4: $client.device,
+                cs5Label: "userDisplayName", cs5: $actor.displayName,
+                cs6Label: "sourceCountry",   cs6: $geo.country,
+                flexString1Label: "eventUuid", flexString1: $d.uuid
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/okta/okta-users.yaml
+++ b/cef/v0/okta/okta-users.yaml
@@ -1,0 +1,59 @@
+name: "Okta Users to CEF"
+description: "Maps Okta Users directory records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "okta-users"
+tags:
+  - "v0"
+  - "cef"
+  - "okta"
+  - "users"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Okta Users (directory) -> CEF intermediate (T1). No escaping here.
+          # signature_id = okta.user.inventory (stable, low-cardinality).
+          # times epoch-ms; custom cs*/cn* slots paired with *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r |
+          ($r.profile // {}) as $p |
+          {
+            _cef: {
+              vendor: "Okta",
+              product: "Okta Users",
+              version: "",
+              signature_id: "okta.user.inventory",
+              name: ("Okta user inventory record: " + ($p.login // $p.email // $r.id)),
+              severity: 2,
+              extension: ( {
+                rt:       to_epoch_ms($r.lastUpdated // $r.created),
+                start:    to_epoch_ms($r.created),
+                end:      to_epoch_ms($r.lastLogin),
+                suser:    ($p.login // $p.email),
+                suid:     $r.id,
+                duser:    $p.displayName,
+                act:      "user-inventory",
+                outcome:  $r.status,
+                cs1Label: "department",       cs1: $p.department,
+                cs2Label: "title",            cs2: $p.title,
+                cs3Label: "manager",          cs3: $p.manager,
+                cs4Label: "credentialProvider", cs4: ($r.credentials.provider.type // null),
+                cs5Label: "employeeNumber",   cs5: $p.employeeNumber,
+                cs6Label: "userType",         cs6: $p.userType,
+                deviceCustomDate1Label: "passwordChanged",
+                deviceCustomDate1: to_epoch_ms($r.passwordChanged)
+              } | with_entries(select(.value != null and .value != "")) )
+            }
+          }

--- a/cef/v0/opencti/opencti-indicators.yaml
+++ b/cef/v0/opencti/opencti-indicators.yaml
@@ -1,0 +1,76 @@
+name: "OpenCTI Indicators to CEF"
+description: "Maps OpenCTI (STIX 2.1) threat-intelligence Indicator records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "opencti-indicators"
+tags:
+  - "v0"
+  - "cef"
+  - "opencti"
+  - "indicators"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # OpenCTI (STIX 2.1) Indicator -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping/header assembly. Emit FINAL-FORM values: severity is an
+          # integer 0-10 (from x_opencti_score/10), times are epoch-MS, and
+          # every cs*/cn* custom slot is paired with its *Label.
+          # One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          . as $r
+          | def to_epoch_ms($ts):
+              if $ts == null then null
+              elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+              else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+              end;
+          ($r.x_opencti_main_observable_type // "indicator") as $mot
+          | ($r.objectMarking[0].definition // null) as $tlp
+          | {
+              _cef: {
+                vendor: "OpenCTI",
+                product: "OpenCTI Indicators",
+                version: ($r.spec_version // ""),
+                signature_id: ("indicator." + ($mot | ascii_downcase)),
+                name: ("OpenCTI indicator: " + ($r.name // $r.pattern // $r.id)),
+                severity: (
+                  if $r.x_opencti_score == null then 0
+                  else (($r.x_opencti_score / 10) | floor
+                        | if . > 10 then 10 elif . < 0 then 0 else . end)
+                  end),
+                extension: ( {
+                  rt:        to_epoch_ms($r.valid_from // $r.created // $r.created_at),
+                  start:     to_epoch_ms($r.valid_from),
+                  end:       to_epoch_ms($r.valid_until),
+                  msg:       ($r.description // null),
+                  externalId: ($r.id // null),
+                  request:   ($r.externalReferences[0].url // null),
+                  outcome:   (if ($r.revoked == true) then "revoked" else "active" end),
+                  suser:     (($r.createdBy.name) // null),
+                  cs1Label:  "indicatorValue",
+                  cs1:       ($r.name // $r.pattern // null),
+                  cs2Label:  "indicatorPattern",
+                  cs2:       ($r.pattern // null),
+                  cs3Label:  "patternType",
+                  cs3:       ($r.pattern_type // null),
+                  cs4Label:  "mainObservableType",
+                  cs4:       ($r.x_opencti_main_observable_type // null),
+                  cs5Label:  "tlp",
+                  cs5:       (if $tlp != null then ($tlp | ltrimstr("TLP:")) else null end),
+                  cs6Label:  "indicatorTypes",
+                  cs6:       (if ($r.indicator_types // null) != null then ($r.indicator_types | join(",")) else null end),
+                  cs7Label:  "labels",
+                  cs7:       (if ($r.labels // null) != null then ($r.labels | join(",")) else null end),
+                  cn1Label:  "openctiScore",
+                  cn1:       ($r.x_opencti_score // null),
+                  cn2Label:  "confidence",
+                  cn2:       ($r.confidence // null)
+                } | with_entries(select(.value != null and .value != "")) )
+              }
+            }

--- a/cef/v0/semgrep/semgrep-chain-findings.yaml
+++ b/cef/v0/semgrep/semgrep-chain-findings.yaml
@@ -1,0 +1,68 @@
+name: "Semgrep Supply Chain Findings to CEF"
+description: "Maps Semgrep Supply Chain (dependency) Findings into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "semgrep-chain-findings"
+tags:
+  - "v0"
+  - "cef"
+  - "semgrep"
+  - "supply-chain"
+  - "vulnerability"
+  - "findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Semgrep Supply Chain Findings -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping. Emit FINAL-FORM values: severity int 0-10, times in
+          # epoch-MILLISECONDS, custom slots paired with their *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          . as $r
+          | ($r.severity // "" | ascii_downcase) as $sev
+          | ($r.found_dependency // {}) as $dep
+          | ($r.rule.cwe_names[0] // null) as $cwe0
+          | (if ($dep.package // null) != null
+             then ($dep.package + (if ($dep.version // null) != null then "@" + $dep.version else "" end))
+             else null end) as $pkg
+          | {
+              _cef: {
+                vendor: "Semgrep",
+                product: "Semgrep Supply Chain",
+                version: "",
+                signature_id: ($r.rule.vulnerability_identifier // $r.rule_name),
+                name: ($r.rule_message // $r.rule_name),
+                severity: (if   $sev == "critical" then 10
+                           elif $sev == "high"     then 8
+                           elif $sev == "medium"   then 5
+                           elif $sev == "low"      then 3
+                           else 2 end),
+                extension: ( {
+                  rt:            to_epoch_ms($r.created_at),
+                  start:         to_epoch_ms($r.relevant_since),
+                  externalId:    ($r.id | tostring),
+                  msg:           $r.rule_message,
+                  fname:         (if ($r.location.file_path // null) != null then ($r.location.file_path | split("/")[-1]) else null end),
+                  filePath:      ($r.location.file_path // null),
+                  outcome:       ($r.status // $r.state),
+                  cn1:           ($r.location.line // null), cn1Label: "startLine",
+                  cs1:           ($r.rule.vulnerability_identifier // null), cs1Label: "cve",
+                  cs2:           $cwe0, cs2Label: "cwe",
+                  cs3:           $pkg, cs3Label: "package",
+                  cs4:           ($dep.ecosystem // null), cs4Label: "ecosystem",
+                  cs5:           ($r.repository.name // null), cs5Label: "repository",
+                  cs6:           ($r.fix_recommendations // [] | (.[0].version // null)), cs6Label: "fixedVersion"
+                } | with_entries(select(.value != null and .value != "")) )
+              }
+            }

--- a/cef/v0/semgrep/semgrep-code-findings.yaml
+++ b/cef/v0/semgrep/semgrep-code-findings.yaml
@@ -1,0 +1,63 @@
+name: "Semgrep Code Vulnerability Findings to CEF"
+description: "Maps Semgrep Code Vulnerability Finding records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "semgrep-code-findings"
+tags:
+  - "v0"
+  - "cef"
+  - "semgrep"
+  - "code"
+  - "vulnerability"
+  - "findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          . as $r
+          | ($r.severity // "" | ascii_downcase) as $sev
+          | (($r.rule.cwe_names // []) | map(select(. != null))) as $cwes
+          | ($cwes | map(split(":")[0] | ascii_upcase) | map(select(startswith("CWE"))) | first) as $cwe_id
+          | ($r.location.file_path // "") as $fp
+          | { _cef: {
+              vendor: "Semgrep",
+              product: "Semgrep Code",
+              version: "",
+              signature_id: ($r.rule_name // "semgrep.finding"),
+              name: ($r.rule_message // $r.rule_name // "Semgrep code finding"),
+              severity: ( if $sev == "critical" then 10
+                          elif $sev == "high" then 8
+                          elif $sev == "medium" then 6
+                          elif $sev == "low" then 3
+                          elif $sev == "info" then 1
+                          else 0 end ),
+              extension: ( {
+                rt:       to_epoch_ms($r.created_at // $r.state_updated_at),
+                msg:      ($r.rule_message // $r.rule_name),
+                fname:    (if $fp != "" then ($fp | split("/")[-1]) else null end),
+                filePath: (if $fp != "" then $fp else null end),
+                request:  $r.line_of_code_url,
+                outcome:  ($r.status // $r.state),
+                cn1Label: "lineNumber",
+                cn1:      $r.location.line,
+                cn2Label: "findingId",
+                cn2:      $r.id,
+                cs1Label: "cwe",
+                cs1:      $cwe_id,
+                cs2Label: "owasp",
+                cs2:      (($r.rule.owasp_names // []) | join(", ") | if . == "" then null else . end),
+                cs3Label: "repository",
+                cs3:      $r.repository.name,
+                cs4Label: "confidence",
+                cs4:      $r.confidence
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/snyk/snyk-issues.yaml
+++ b/cef/v0/snyk/snyk-issues.yaml
@@ -1,0 +1,60 @@
+name: "Snyk Issue Findings to CEF"
+description: "Maps Snyk Issue Findings into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "snyk-issues"
+tags:
+  - "v0"
+  - "cef"
+  - "snyk"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Snyk /issues -> CEF intermediate (T1). NO escaping here.
+          # severity: integer 0-10 ; rt/start: epoch-MILLISECONDS ;
+          # custom slots cs*/cn* always paired with their *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.attributes // {}) as $a
+          | ($a.coordinates[0].representations[0].dependency // {}) as $dep
+          | ( [ $a.problems[]? | select(.source == "NVD") | .id ] | first ) as $cve
+          | ( [ $a.classes[]?  | select(.source == "CWE") | .id ] | first ) as $cwe
+          | ( [ $a.severities[]? | select(.score != null) | .score ] | first ) as $cvss
+          | { _cef: {
+              vendor: "Snyk",
+              product: "Snyk",
+              version: "",
+              signature_id: ($a.key // $r.id),
+              name: ($a.title // "Snyk Issue"),
+              severity: (
+                { "info": 1, "low": 3, "medium": 5, "high": 8, "critical": 10 }[$a.effective_severity_level] // 0
+              ),
+              extension: ( {
+                rt:      to_epoch_ms($a.updated_at),
+                start:   to_epoch_ms($a.created_at),
+                outcome: $a.status,
+                msg:     $a.description,
+                reason:  $a.effective_severity_level,
+                request: ($a.problems[0].url // null),
+                cs1Label: "packageName",   cs1: $dep.package_name,
+                cs2Label: "packageVersion", cs2: $dep.package_version,
+                cs3Label: "cve",           cs3: $cve,
+                cs4Label: "cwe",           cs4: $cwe,
+                cs5Label: "snykIssueId",   cs5: $r.id,
+                cs6Label: "issueType",     cs6: $a.type,
+                cn1Label: "cvssBaseScore", cn1: $cvss
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/tenable/tenable-assets.yaml
+++ b/cef/v0/tenable/tenable-assets.yaml
@@ -1,0 +1,60 @@
+name: "Tenable Assets to CEF"
+description: "Maps Tenable Vulnerability Management asset inventory records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "tenable-assets"
+tags:
+  - "v0"
+  - "cef"
+  - "tenable"
+  - "asset"
+  - "inventory"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # Tenable asset inventory -> CEF intermediate (T1). No escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. Emit FINAL-FORM
+          # values: severity int 0-10; times epoch-MILLISECONDS; custom slots
+          # cs* paired with their *Label. One jq pass; shallow null-drop.
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          . as $r |
+          { _cef: {
+              vendor: "Tenable",
+              product: "Tenable Vulnerability Management",
+              version: "",
+              signature_id: "tenable:asset:inventory",
+              name: "Tenable Asset Inventory",
+              # Asset inventory snapshots are informational (CEF severity 2).
+              severity: 2,
+              extension: ( {
+                rt:               to_epoch_ms($r.updated_at),
+                start:            to_epoch_ms($r.first_seen),
+                end:              to_epoch_ms($r.last_seen),
+                externalId:       $r.id,
+                dhost:            (($r.hostnames // [])[0]),
+                dst:              (($r.ipv4s // [])[0]),
+                dmac:             (($r.mac_addresses // [])[0]),
+                act:              "inventory",
+                cs1Label:         "operatingSystem",
+                cs1:              (($r.operating_systems // [])[0]),
+                cs2Label:         "systemType",
+                cs2:              (($r.system_types // [])[0]),
+                cs3Label:         "cloudRegion",
+                cs3:              $r.aws_region,
+                cs4Label:         "cloudInstanceId",
+                cs4:              $r.aws_ec2_instance_id,
+                cs5Label:         "fqdn",
+                cs5:              (($r.fqdns // [])[0]),
+                cn1Label:         "exposureScore",
+                cn1:              $r.exposure_score
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/tenable/tenable-vulnerabilities.yaml
+++ b/cef/v0/tenable/tenable-vulnerabilities.yaml
@@ -1,0 +1,82 @@
+name: "Tenable Vulnerability Findings to CEF"
+description: "Maps Tenable Vulnerability Management finding records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "tenable-vulnerabilities"
+tags:
+  - "v0"
+  - "cef"
+  - "tenable"
+  - "vulnerability"
+  - "findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Tenable Vulnerability Management -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (mapped from the Tenable severity label)
+          #   - time fields (rt/start/end): epoch-MILLISECONDS
+          #   - custom slots cs*/cn* ALWAYS paired with their *Label
+          # One jq pass, per-record only; shallow null-drop on extension.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          # Tenable severity label -> CEF severity 0-10.
+          def sev_0_10($s):
+            ($s // "" | ascii_downcase | gsub("^\\s+|\\s+$"; "")) as $x |
+            if   $x == "info" or $x == "informational" then 0
+            elif $x == "low"      then 3
+            elif $x == "medium"   then 5
+            elif $x == "high"     then 8
+            elif $x == "critical" then 10
+            else 0 end;
+
+          . as $r
+          | ( $r.plugin // {} ) as $p
+          | ( $r.asset  // {} ) as $a
+          | ( ( ($p.cve // [])
+                + [ ($p.xrefs // [])[] | select(.type == "CVE") | "CVE-" + (.id | ltrimstr("CVE-")) ] )
+              | unique ) as $cves
+          | { _cef: {
+              vendor: "Tenable",
+              product: "Tenable Vulnerability Management",
+              version: "",
+              signature_id: ($p.id | tostring),          # stable Tenable plugin id
+              name: ($p.name),                            # human-readable plugin title
+              severity: sev_0_10($r.severity),
+              extension: ( {
+                rt:       to_epoch_ms($r.scan.started_at),
+                start:    to_epoch_ms($r.first_found),
+                end:      to_epoch_ms($r.last_found),
+                dhost:    ($a.fqdn // $a.hostname),
+                dst:      $a.ipv4,
+                dmac:     $a.mac_address,
+                outcome:  $r.state,
+                msg:      ($p.synopsis // $p.description),
+                # CVSS base score -> numeric custom slot.
+                cn1Label: "cvssBaseScore",
+                cn1:      ($p.cvss3_base_score // $p.cvss_base_score),
+                # First CVE and full CVE list -> string custom slots.
+                cs1Label: "cve",
+                cs1:      ($cves | first),
+                cs2Label: "cveList",
+                cs2:      (if ($cves | length) > 0 then ($cves | join(",")) else null end),
+                cs3Label: "cvss3Vector",
+                cs3:      ($p.cvss3_vector.raw),
+                cs4Label: "solution",
+                cs4:      ($p.solution),
+                cs5Label: "pluginFamily",
+                cs5:      ($p.family)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/wiz/wiz-cloud-configuration-findings.yaml
+++ b/cef/v0/wiz/wiz-cloud-configuration-findings.yaml
@@ -1,0 +1,61 @@
+name: "Wiz Cloud Configuration Findings to CEF"
+description: "Maps Wiz Cloud Configuration Findings records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "wiz-cloud-configuration-findings"
+tags:
+  - "v0"
+  - "cef"
+  - "wiz"
+  - "cloud-configuration-findings"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Wiz Cloud Configuration Findings -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # severity: integer 0-10; times epoch-MILLISECONDS; custom slots
+          # cs*/cn* always paired with their *Label. One jq pass; shallow
+          # null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.resource // {}) as $res
+          | ($r.rule // {}) as $rule
+          | (($r.securitySubCategories // [])[0]) as $ssc
+          | { _cef: {
+              vendor: "Wiz",
+              product: "Wiz Cloud Configuration Findings",
+              version: "",
+              signature_id: ($rule.shortId // $rule.id // "wiz-config-finding"),
+              name: ($rule.name // "Wiz cloud configuration finding"),
+              severity: (
+                { "INFORMATIONAL": 1, "LOW": 3, "MEDIUM": 5, "HIGH": 8, "CRITICAL": 10 }[($r.severity // "") | ascii_upcase] // 0
+              ),
+              extension: ( {
+                rt:                to_epoch_ms($r.firstSeenAt),
+                end:               to_epoch_ms($r.analyzedAt),
+                externalId:        ($r.id // null),
+                msg:               ($rule.description // null),
+                outcome:           ($r.result // null),
+                act:               ($r.status // null),
+                deviceExternalId:  ($res.providerId // $res.id // null),
+                dvchost:           ($res.name // null),
+                cs1Label: "resourceType",       cs1: ($res.type // null),
+                cs2Label: "cloudProvider",       cs2: ($res.cloudPlatform // null),
+                cs3Label: "cloudRegion",         cs3: ($res.region // null),
+                cs4Label: "cloudAccountId",      cs4: ($res.subscription.externalId // null),
+                cs5Label: "complianceStandard",  cs5: ($ssc.category.framework.name // null),
+                cs6Label: "remediation",         cs6: ($r.remediation // null)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/wiz/wiz-vulnerabilities.yaml
+++ b/cef/v0/wiz/wiz-vulnerabilities.yaml
@@ -1,0 +1,81 @@
+name: "Wiz Vulnerabilities to CEF"
+description: "Maps Wiz vulnerability finding records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "wiz-vulnerabilities"
+tags:
+  - "v0"
+  - "cef"
+  - "wiz"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Wiz Vulnerabilities -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (mapped from Wiz vendorSeverity)
+          #   - time fields (rt/end): epoch-MILLISECONDS
+          #   - custom slots cs*/cn* ALWAYS paired with their *Label
+          # One jq pass, per-record only; shallow null-drop on extension.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.vulnerableAsset // {}) as $a
+          | ($r.name // $r.Name) as $cve_id
+          | ($r.vendorSeverity // $r.VendorSeverity) as $vsev
+          | ($a.ipAddresses // $r.IpAddresses // []) as $ips
+          | { _cef: {
+              vendor: "Wiz",
+              product: "Wiz Vulnerabilities",
+              version: "",
+              signature_id: ($cve_id // "wiz-vulnerability-finding"),
+              name: (
+                "Wiz vulnerability "
+                + ($cve_id // "finding")
+                + " on " + ($a.name // $r.AssetName // "asset")
+              ),
+              severity: (
+                { "CRITICAL": 10, "Critical": 10, "HIGH": 8, "High": 8,
+                  "MEDIUM": 6, "Medium": 6, "LOW": 3, "Low": 3,
+                  "INFORMATIONAL": 1, "Informational": 1 }[$vsev] // 0
+              ),
+              extension: ( {
+                rt:          to_epoch_ms($r.firstDetectedAt // $r.FirstDetected),
+                end:         to_epoch_ms($r.lastDetectedAt // $r.LastDetected),
+                externalId:  ($r.id // $r.ID),
+                msg:         ($r.description // $r.Description),
+                outcome:     ($r.status // $r.FindingStatus),
+                dhost:       ($a.name // $r.AssetName),
+                dvchost:     ($a.name // $r.AssetName),
+                dst:         ([ $ips[] | select(test("^(\\d{1,3}\\.){3}\\d{1,3}$")) ] | first),
+                request:     ($r.portalUrl // $r.WizURL),
+                filePath:    ($r.locationPath // $r.LocationPath),
+                # --- custom string slots (paired labels) ---
+                cs1Label: "cve",              cs1: $cve_id,
+                cs2Label: "vendorSeverity",   cs2: $vsev,
+                cs3Label: "affectedPackage",  cs3: (
+                  ($r.detailedName // $r.DetailedName // "")
+                  + (if ($r.version // $r.Version) then ("@" + ($r.version // $r.Version)) else "" end)
+                  | if . == "" then null else . end
+                ),
+                cs4Label: "fixedVersion",     cs4: ($r.fixedVersion // $r.FixedVersion),
+                cs5Label: "cloudProvider",    cs5: ($a.cloudPlatform // $r.CloudPlatform),
+                cs6Label: "cloudAccount",     cs6: ($a.subscriptionId // $r.SubscriptionId),
+                # --- custom number slots (paired labels) ---
+                cn1Label: "cvssBaseScore",    cn1: ($r.score // $r.Score),
+                cn2Label: "exploitability",   cn2: ($r.exploitabilityScore // $r.ExploitabilityScore),
+                cn3Label: "hasExploit",       cn3: (if ($r.hasExploit // $r.HasExploit) then 1 else 0 end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/utility/cef/cef-serializer.yaml
+++ b/utility/cef/cef-serializer.yaml
@@ -1,0 +1,60 @@
+name: "CEF Serializer"
+description: "Shared, source-agnostic serializer that renders a normalized {_cef:{...}} intermediate into a CEF:0 message string. Chain it after any per-source cef/ mapping transform. Owns all CEF escaping, header assembly, and severity clamping so per-source transforms never touch escaping."
+author: "Monad"
+contributors:
+  - "https://github.com/kennethkaye"
+inputs: []
+tags:
+  - "v0"
+  - "cef"
+  - "serializer"
+  - "utility"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ============================================================
+          # CEF Serializer (T2) — {_cef:{...}} intermediate -> {message:"CEF:0|..."}
+          # Owns ALL CEF serialization: escaping, header assembly, severity
+          # clamp. Per-source mapping transforms (T1) emit final-form values
+          # under _cef and do NO escaping. See the ecs/ocsf skills' sibling
+          # docs; CEF spec: references/cef-format.md.
+          #
+          # Escaping (backslash FIRST):
+          #   header field: \ -> \\ , | -> \|            (= not escaped)
+          #   extension value: \ -> \\ , = -> \= , newlines -> \n / \r  (| not escaped)
+          # The `contains` guards short-circuit the regex engine on clean
+          # values (the overwhelmingly common case).
+          # ============================================================
+
+          def cef_esc_header:
+            tostring
+            | if (contains("\\") or contains("|"))
+              then gsub("\\\\"; "\\\\") | gsub("\\|"; "\\|")
+              else . end;
+
+          def cef_esc_ext:
+            tostring
+            | if (contains("\\") or contains("=") or contains("\n") or contains("\r"))
+              then gsub("\\\\"; "\\\\") | gsub("="; "\\=") | gsub("\n"; "\\n") | gsub("\r"; "\\r")
+              else . end;
+
+          def cef_sev($n):
+            if ($n | type) != "number" then 0
+            else ([[($n | floor), 0] | max, 10] | min) end;
+
+          def cef_ext($obj):
+            [ $obj | to_entries[]
+              | select(.value != null and .value != "")
+              | "\(.key)=\(.value | cef_esc_ext)" ]
+            | join(" ");
+
+          ._cef as $c
+          | { "message":
+              ( "CEF:0|"
+                + ([$c.vendor, $c.product, $c.version, $c.signature_id, $c.name]
+                   | map(cef_esc_header) | join("|"))
+                + "|" + (cef_sev($c.severity) | tostring)
+                + "|" + cef_ext($c.extension // {}) ) }


### PR DESCRIPTION
Adds the two-transform CEF chain: per-source `{_cef}` mappings under `cef/v0/<vendor>/` plus the shared `utility/cef/cef-serializer.yaml` (T2, owns all escaping). Authored with the `cef-transform-builder` skill; each chain validated with `validate-cef.sh` (`ERRORS: none`). Batch 1 covers the same 30 inputs.

**Note:** This is **batch 1 of 2** (30 high-value, ground-truth + well-documented inputs spanning every category). The remaining ~258 FIT inputs are being authored from vendor documentation on the same validator-gated harness and will be pushed to this branch shortly. Every transform here passed its format's offline validator before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)