### PR TITLE
feat(cef): vendor→CEF v0 transforms (batch 2 + cursor)

### DIFF
--- a/cef/v0/abnormal/abnormal-audit-logs.yaml
+++ b/cef/v0/abnormal/abnormal-audit-logs.yaml
@@ -1,0 +1,61 @@
+name: "Abnormal Security Audit Logs to CEF"
+description: "Maps Abnormal Security portal/API audit-log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "abnormal-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "abnormal"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Abnormal Security Audit Logs -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns that.
+          # Emit FINAL-FORM values: severity int 0-10, times epoch-MS,
+          # custom slots paired with *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.abx_metadata // {}) as $m
+          | ($r.abx_body // {}) as $b
+          | ($b.action_details // {}) as $ad
+          | ($b.user // {}) as $u
+          | (($b.status // "") | ascii_upcase) as $status
+          | {
+              _cef: {
+                vendor:  "Abnormal Security",
+                product: "Abnormal Audit Logs",
+                version: "",
+                signature_id: ($b.action // $b.category // "audit_log"),
+                name: (($b.action // $b.category // "audit log event")
+                       + (if $status != "" then " (" + $status + ")" else "" end)),
+                # SUCCESS = low/informational (3); FAILURE = elevated (6).
+                severity: (if $status == "FAILURE" then 6 else 3 end),
+                extension: ( {
+                  rt:       to_epoch_ms($b.timestamp // $m.timestamp),
+                  suser:    $u.email,
+                  src:      $b.source_ip,
+                  act:      $b.action,
+                  outcome:  $status,
+                  request:  $ad.request_url,
+                  reason:   $ad.provided_reason,
+                  cs1Label: "tenantName",   cs1: $b.tenant_name,
+                  cs2Label: "category",     cs2: $b.category,
+                  cs3Label: "traceId",      cs3: $m.trace_id,
+                  cs4Label: "messageId",    cs4: $ad.message_id
+                } | with_entries(select(.value != null and .value != "")) )
+              }
+            }

--- a/cef/v0/abnormal/abnormal-cases.yaml
+++ b/cef/v0/abnormal/abnormal-cases.yaml
@@ -1,0 +1,60 @@
+name: "Abnormal Security Cases to CEF"
+description: "Maps Abnormal Security case records (account-takeover / email-security cases from the /v1/cases API) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "abnormal-cases"
+tags:
+  - "v0"
+  - "cef"
+  - "abnormal"
+  - "cases"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Abnormal Security case -> CEF intermediate (T1). No escaping here;
+          # the shared CEF Serializer (T2) owns all escaping. Emit final-form
+          # values: severity int 0-10, times epoch-MILLISECONDS, custom slots
+          # paired with *Label. One jq pass; shallow null-drop on extension.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ((($r.severity // "") | ascii_downcase)) as $sev
+          # Source severity text -> CEF severity bucket (0-10).
+          | (if   ($sev | test("takeover|compromis|exfiltrat")) then 8
+             elif  ($sev | test("phish|fraud|impersonat"))      then 6
+             elif  ($sev == "")                                 then 0
+             else                                                    5
+             end) as $severity
+
+          | { _cef: {
+                vendor:  "Abnormal Security",
+                product: "Abnormal Behavior Platform",
+                version: "",
+                signature_id: ($r.severity // "Abnormal Case"),   # case classification
+                name: ("Abnormal case: " + ($r.severity // "Case")
+                        + (if $r.affectedEmployee != null then " for " + $r.affectedEmployee else "" end)),
+                severity: $severity,
+                extension: ( {
+                    rt:     to_epoch_ms($r.firstObserved),
+                    suser:  $r.affectedEmployee,
+                    cat:    $r.analysis,
+                    reason: $r.description,
+                    msg:    ($r.genai_summary // $r.description),
+                    cs1Label: "abnormalCaseId",     cs1: ($r.caseId | tostring),
+                    cs2Label: "caseStatus",         cs2: $r.case_status,
+                    cs3Label: "remediationStatus",  cs3: $r.remediation_status,
+                    cs4Label: "abnormalSeverity",   cs4: $r.severity,
+                    cs5Label: "threatIds",          cs5: (($r.threatIds // []) | join(","))
+                  } | with_entries(select(.value != null and .value != "")) )
+            } }

--- a/cef/v0/abnormal/abnormal-threats.yaml
+++ b/cef/v0/abnormal/abnormal-threats.yaml
@@ -1,0 +1,64 @@
+name: "Abnormal Security Threats to CEF"
+description: "Maps Abnormal Security threat (malicious email) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "abnormal-threats"
+tags:
+  - "v0"
+  - "cef"
+  - "abnormal"
+  - "threats"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Abnormal Security threat -> CEF intermediate (T1). No escaping —
+          # the shared CEF Serializer (T2) owns all escaping. Final-form
+          # values only: severity int 0-10, times epoch-MS, custom slots
+          # cs*/cn* paired with *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | { _cef: {
+              vendor: "Abnormal Security",
+              product: "Abnormal Inbound Email Security",
+              version: "",
+              signature_id: ($r.attackType // "Threat"),        # low-cardinality attack class
+              name: (($r.attackType // "Email Threat") + ": " + ($r.subject // "")),
+              severity: 8,                                       # detected threat -> High
+              extension: ( {
+                rt:       to_epoch_ms($r.receivedTime),
+                start:    to_epoch_ms($r.sentTime),
+                end:      to_epoch_ms($r.remediationTimestamp),
+                suser:    $r.recipientAddress,                   # attacked mailbox
+                duser:    $r.recipientAddress,
+                src:      $r.senderIpAddress,
+                msg:      $r.subject,
+                act:      $r.remediationStatus,
+                outcome:  (if (($r.remediationStatus // "") | ascii_downcase | test("remediat")) then "REMEDIATED" else "DETECTED" end),
+                suid:     ($r.fromAddress),
+                sourceServiceName: "Abnormal Threats",
+                fileName: (($r.attachmentNames // []) | join(", ")),
+                cnt:      $r.attachmentCount,
+                # --- custom slots (always paired with *Label) ---
+                cs1Label: "attackType",       cs1: $r.attackType,
+                cs2Label: "attackStrategy",    cs2: $r.attackStrategy,
+                cs3Label: "attackVector",      cs3: $r.attackVector,
+                cs4Label: "impersonatedParty", cs4: $r.impersonatedParty,
+                cs5Label: "attackedParty",     cs5: $r.attackedParty,
+                cs6Label: "threatId",          cs6: $r.threatId,
+                externalId: $r.abxMessageIdStr,
+                cn1Label: "urlCount",          cn1: $r.urlCount,
+                deviceCustomDate1Label: "sentTime", deviceCustomDate1: to_epoch_ms($r.sentTime)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aikido/aikido-activity-log.yaml
+++ b/cef/v0/aikido/aikido-activity-log.yaml
@@ -1,0 +1,62 @@
+name: "Aikido Activity Log to CEF"
+description: "Maps Aikido Security activity log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aikido-activity-log"
+tags:
+  - "v0"
+  - "cef"
+  - "aikido"
+  - "activity-log"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Aikido Security activity log -> CEF intermediate (T1).
+          # No escaping here (the shared CEF Serializer T2 owns escaping).
+          # Emit final-form values: severity int 0-10, times epoch-MS,
+          # custom cs*/cn* slots each paired with their *Label. One jq pass;
+          # shallow null-drop on the extension object (no recursive walk).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number"
+              then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.action // "") as $action
+          | ($r.metadata.location // {}) as $loc
+          | { _cef: {
+              vendor: "Aikido Security",
+              product: "Aikido Activity Log",
+              version: "",
+              signature_id: $action,
+              name: ($r.comment // $action),
+              severity: ( { "re_open": 4, "adjust_severity": 4,
+                            "closed": 3, "snoozed": 2, "unsnoozed": 3,
+                            "ignored": 2, "auto_ignored": 2,
+                            "autofix_pr_created": 3, "drata_push": 2,
+                            "sprinto_push": 2, "thoropass_push": 2 }[$action] // 2 ),
+              extension: ( {
+                rt:    to_epoch_ms($r.timestamp),
+                suser: $r.user_name,
+                suid:  ($r.user_id | tostring),
+                act:   $action,
+                msg:   $r.comment,
+                cn3Label: "activityId",        cn3: $r.id,
+                cs1Label: "source",           cs1: $r.source,
+                cs2Label: "codeRepoName",      cs2: $loc.code_repo_name,
+                cs3Label: "containerRepoName", cs3: $loc.container_repo_name,
+                cs4Label: "cloudName",         cs4: $loc.cloud_name,
+                cs5Label: "domainName",        cs5: $loc.domain_name,
+                cn1Label: "issueId",           cn1: $r.issue_id,
+                cn2Label: "groupedIssueId",    cn2: $r.grouped_issue_id
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aikido/aikido-issues.yaml
+++ b/cef/v0/aikido/aikido-issues.yaml
@@ -1,0 +1,58 @@
+name: "Aikido Issues to CEF"
+description: "Maps Aikido Security issue export records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aikido-issues"
+tags:
+  - "v0"
+  - "cef"
+  - "aikido"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Aikido Issues -> CEF intermediate (T1). No escaping here — the
+          # shared CEF Serializer (T2) owns all escaping. Final-form values:
+          # severity int 0-10, times epoch-ms, cs*/cn* slots paired w/ labels.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else null end;
+          . as $r
+          | ($r.severity // "" | ascii_downcase) as $sev
+          | ($r.code_repo_name // $r.container_repo_name // $r.cloud_name // $r.domain_name // $r.virtual_machine_name) as $asset
+          | { _cef: {
+              vendor: "Aikido Security",
+              product: "Aikido",
+              version: "",
+              signature_id: (($r.rule_id // ($r.type + "-issue")) | tostring),
+              name: ($r.rule // "Aikido security issue"),
+              severity: ( { "critical": 10, "high": 8, "medium": 5, "low": 3 }[$sev] // 0 ),
+              extension: ( {
+                rt:        to_epoch_ms($r.first_detected_at),
+                end:       to_epoch_ms($r.closed_at),
+                outcome:   (if $r.status == "closed" then "Closed" elif $r.status != null then ($r.status | ascii_upcase[0:1] + ($r.status[1:])) else null end),
+                cat:       ($r.type),
+                msg:       ($r.rule),
+                filePath:  ($r.affected_file),
+                fname:     (if $r.affected_file != null then ($r.affected_file | split("/") | last) else null end),
+                cs1Label:  "cveId",            cs1: ($r.cve_id),
+                cs2Label:  "affectedPackage",  cs2: ($r.affected_package),
+                cs3Label:  "installedVersion", cs3: ($r.installed_version),
+                cs4Label:  "asset",            cs4: ($asset),
+                cs5Label:  "attackSurface",    cs5: ($r.attack_surface),
+                cs6Label:  "exploitability",   cs6: ($r.exploitability),
+                cn1Label:  "severityScore",    cn1: ($r.severity_score),
+                cn2Label:  "cvssScore",        cn2: ($r.original_cvss_severity_score),
+                cn3Label:  "slaDays",          cn3: ($r.sla_days),
+                flexString1Label: "issueId",   flexString1: (($r.id | tostring)),
+                flexString2Label: "status",    flexString2: ($r.status)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aiven/aiven-service-logs.yaml
+++ b/cef/v0/aiven/aiven-service-logs.yaml
@@ -1,0 +1,77 @@
+name: "Aiven Service Logs to CEF"
+description: "Maps Aiven managed-service journald log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aiven-service-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "aiven"
+  - "system"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Aiven Service Logs -> CEF intermediate (T1).
+          # Input: ONE Aiven service-log record (a systemd journal entry from
+          # any Aiven managed service). No escaping here — the shared CEF
+          # Serializer (T2) owns all escaping. Emit FINAL-FORM values:
+          #   severity 0-10, times epoch-MILLISECONDS, cs* slots + *Label.
+          # One jq pass; shallow null-drop on the extension object only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          . as $r
+          | ( (.PRIORITY // "") | if type == "number" then tostring else . end ) as $prio
+          | ( { "0": "emergency", "1": "alert", "2": "critical", "3": "error",
+                "4": "warning", "5": "notice", "6": "informational", "7": "debug" }[$prio] ) as $sevname
+          # journald/syslog PRIORITY (0 emerg .. 7 debug) -> CEF severity 0-10.
+          | ( { "0": 10, "1": 10, "2": 9, "3": 8, "4": 6, "5": 4, "6": 3, "7": 1 }[$prio] // 0 ) as $sev
+          | ( $r.SYSTEMD_UNIT // "" ) as $unit
+          | ( if $unit != "" then ($unit | sub("\\.service$"; "") | sub("-[0-9].*$"; "")) else null end ) as $svc
+          | ( ($r.MESSAGE // "") | capture("user=(?<user>[^,]*),db=(?<db>[^,]*),app=(?<app>[^,]*),client=(?<client>[^ ]*)") ? // {} ) as $pg
+          | ( if ($pg.user // "") != "" then $pg.user else null end ) as $puser
+          | ( if is_ip($pg.client // "") then $pg.client else null end ) as $pclient
+          | ( ($r.MESSAGE // "") | test("authentication|password"; "i") ) as $is_auth
+          | ( ($r.MESSAGE // "") | test("fatal|fail|denied|error"; "i") or ($prio == "0" or $prio == "1" or $prio == "2" or $prio == "3") ) as $is_fail
+
+          | { _cef: {
+              vendor: "Aiven",
+              product: "Aiven Service Logs",
+              version: "",
+              signature_id: ("aiven." + ($svc // "service-log")),
+              name: ("Aiven " + ($svc // "service") + " log message"),
+              severity: $sev,
+              extension: ( {
+                rt:      to_epoch_ms($r.timestamp),
+                dvchost: $r.HOSTNAME,
+                suser:   $puser,
+                src:     $pclient,
+                msg:     $r.MESSAGE,
+                cat:     $svc,
+                outcome: ( if $is_auth then (if $is_fail then "FAILURE" else "SUCCESS" end) else null end ),
+                cs1Label: "syslogSeverity", cs1: $sevname,
+                cs2Label: "sessionId",      cs2: $r.SESSION_ID,
+                cs3Label: "systemdUnit",    cs3: ( if $unit != "" then $unit else null end ),
+                cs4Label: "database",       cs4: ( if ($pg.db // "") != "" then $pg.db else null end )
+              }
+              # Drop a cs* value with no data together with its orphaned label.
+              | ( if .cs1 == null then del(.cs1, .cs1Label) else . end )
+              | ( if .cs2 == null then del(.cs2, .cs2Label) else . end )
+              | ( if .cs3 == null then del(.cs3, .cs3Label) else . end )
+              | ( if .cs4 == null then del(.cs4, .cs4Label) else . end )
+              | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/alienvault/alienvault-otx-subscribed-pulses.yaml
+++ b/cef/v0/alienvault/alienvault-otx-subscribed-pulses.yaml
@@ -1,0 +1,72 @@
+name: "AlienVault OTX Subscribed Pulses to CEF"
+description: "Maps AlienVault OTX subscribed-pulse threat-intelligence records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "alienvault-otx-subscribed-pulses"
+tags:
+  - "v0"
+  - "cef"
+  - "alienvault"
+  - "subscribed-pulses"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AlienVault OTX subscribed pulse -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping. Final-form values only: severity integer 0-10, times
+          # epoch-MS, custom slots paired with *Label. One jq pass; shallow
+          # null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | (try fromdateiso8601 catch null)) as $e
+                  | if $e == null then null else ($e * 1000) end)
+            end;
+          def joinlist($a): if ($a | length) == 0 then null else ($a | map(tostring) | join(", ")) end;
+
+          . as $p
+          | ($p.indicators // []) as $ind
+          | (($p.TLP // "") | ascii_upcase) as $tlp
+          | ($p.references // []) as $refs
+          | {
+              _cef: {
+                vendor:  "AlienVault",
+                product: "Open Threat Exchange",
+                version: (($p.revision // "") | tostring),
+                signature_id: "otx.pulse.subscribed",
+                name: ($p.name // "OTX Pulse"),
+                # TLP used as an urgency proxy (0-10); OTX carries no severity.
+                severity: ({ "RED": 8, "AMBER": 6, "GREEN": 4, "WHITE": 2, "CLEAR": 2 }[$tlp] // 3),
+                extension: ( {
+                  rt:         to_epoch_ms($p.modified),
+                  start:      to_epoch_ms($p.created),
+                  end:        to_epoch_ms($p.modified),
+                  externalId: ($p.id | tostring),
+                  msg:        $p.description,
+                  cat:        "Threat Intelligence",
+                  request:    ($refs[0]),
+                  suser:      $p.author_name,
+                  cnt:        ($ind | length),
+                  # first IP / hash indicator surfaced into standard slots
+                  src:      ([ $ind[] | select(.type // "" | ascii_downcase | startswith("ipv")) | .indicator ][0]),
+                  fileHash: ([ $ind[] | select(.type // "" | ascii_downcase | startswith("filehash")) | .indicator ][0]),
+                  dhost:    ([ $ind[] | select((.type // "") == "domain" or (.type // "") == "hostname") | .indicator ][0]),
+                  # custom slots (always paired with a *Label)
+                  cs1Label: "tlp",                cs1: (if $tlp == "" then null else $tlp end),
+                  cs2Label: "adversary",          cs2: $p.adversary,
+                  cs3Label: "malwareFamilies",    cs3: joinlist($p.malware_families // []),
+                  cs4Label: "attackIds",          cs4: joinlist($p.attack_ids // []),
+                  cs5Label: "targetedCountries",  cs5: joinlist($p.targeted_countries // []),
+                  cs6Label: "tags",               cs6: joinlist($p.tags // []),
+                  cn1Label: "indicatorCount",     cn1: ($ind | length),
+                  cn2Label: "revision",           cn2: $p.revision
+                } | with_entries(select(.value != null and .value != "")) )
+              }
+            }

--- a/cef/v0/anthropic/anthropic-chat-messages.yaml
+++ b/cef/v0/anthropic/anthropic-chat-messages.yaml
@@ -1,0 +1,65 @@
+name: "Anthropic Claude.ai Chat Messages to CEF"
+description: "Maps Anthropic Compliance API chat message records (anthropic-chat-messages) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "anthropic-chat-messages"
+tags:
+  - "v0"
+  - "cef"
+  - "anthropic"
+  - "chat-messages"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Anthropic Compliance API chat message -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping. Emit FINAL-FORM values: severity int 0-10, times as
+          # epoch-MILLISECONDS, every cs*/cn* slot paired with its *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.chat_user // {}) as $cu
+          | ($r.role // "unknown") as $role
+          | ([ ($r.content // [])[]? | .type ] | map(select(. != null)) | unique) as $ctypes
+          | ([ ($r.content // [])[]? | select(.type == "text") | .text ]
+             | map(select(. != null)) | join(" ")) as $text
+          | (if ($text | length) > 512 then ($text[0:512]) else $text end) as $preview
+
+          | { _cef: {
+              vendor: "Anthropic",
+              product: "Claude.ai",
+              version: "",
+              signature_id: ("chat.message." + $role),
+              name: ("Claude.ai " + $role + " chat message"),
+              severity: 2,
+              extension: ( {
+                rt:      to_epoch_ms($r.created_at),
+                suser:   $cu.email_address,
+                suid:    $cu.id,
+                act:     $role,
+                outcome: "SUCCESS",
+                cat:     "chat-message",
+                externalId: $r.id,
+                msg:     (if $preview == "" then null else $preview end),
+                cs1Label: "chatId",            cs1: $r.chat_id,
+                cs2Label: "chatName",          cs2: $r.chat_name,
+                cs3Label: "projectId",         cs3: $r.project_id,
+                cs4Label: "contentTypes",      cs4: ($ctypes | join(",")),
+                cs5Label: "organizationUuid",  cs5: $r.organization_uuid,
+                cs6Label: "organizationId",    cs6: $r.organization_id,
+                cn1Label: "contentChars",      cn1: (if ($text | length) > 0 then ($text | length) else null end),
+                cn2Label: "fileCount",         cn2: (($r.files // []) | length),
+                cn3Label: "artifactCount",     cn3: (($r.artifacts // []) | length)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/anthropic/anthropic-claude-code.yaml
+++ b/cef/v0/anthropic/anthropic-claude-code.yaml
@@ -1,0 +1,104 @@
+name: "Anthropic Claude Code (OTLP) to CEF"
+description: "Maps one OTLP log record from Claude Code into the normalized {_cef:{...}} CEF intermediate (Vendor Anthropic, Product Claude Code). Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string. signature_id is the low-cardinality event name; token counts and cost ride custom cn*/cs* slots with labels."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "anthropic-claude-code"
+tags:
+  - "v0"
+  - "cef"
+  - "anthropic"
+  - "ai"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Anthropic Claude Code RAW OTLP logs -> CEF intermediate (T1).
+          # One OTLP envelope in -> one _cef object (first logRecord).
+          # Do NOT escape anything here — the shared CEF Serializer (T2)
+          # owns all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10
+          #   - rt: epoch-MILLISECONDS
+          #   - custom slots cs*/cn* ALWAYS paired with their *Label
+          # One jq pass, per-record only; shallow with_entries null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000) end;
+          def nano2ms($n):
+            if $n == null or $n == "" then null else (($n | tonumber) / 1000000 | floor) end;
+          def truthy($v): ($v == true) or (($v | type) == "string" and ($v | ascii_downcase) == "true");
+
+          def av($v):
+            if $v == null then null
+            elif $v.stringValue != null then $v.stringValue
+            elif $v.intValue != null then ($v.intValue | tonumber)
+            elif $v.doubleValue != null then $v.doubleValue
+            elif $v.boolValue != null then $v.boolValue
+            elif $v.arrayValue != null then ((($v.arrayValue.values) // []) | map(av(.)))
+            elif $v.kvlistValue != null then
+              (reduce ((($v.kvlistValue.values) // [])[]) as $a ({}; .[$a.key] = av($a.value)))
+            else null end;
+          def kv($arr): reduce (($arr // [])[]) as $a ({}; .[$a.key] = av($a.value));
+
+          [ (.resourceLogs // [])[] as $rl
+            | kv($rl.resource.attributes) as $res
+            | ($rl.scopeLogs // [])[] as $sl
+            | ($sl.logRecords // [])[] as $lr
+            | ($res + kv($lr.attributes)) as $r
+            | ( ($lr.body.stringValue) as $b
+                | if ($b != null and ($b | startswith("claude_code."))) then $b
+                  elif (($r["event.name"]) // "") != "" then ("claude_code." + $r["event.name"])
+                  else ($b // "claude_code.unknown") end ) as $en
+            | (if (($r["event.timestamp"]) // "") != "" then to_epoch_ms($r["event.timestamp"])
+               else nano2ms($lr.timeUnixNano) end) as $rt
+
+            # outcome + severity buckets (0-10)
+            | ( if ($en == "claude_code.api_error" or $en == "claude_code.api_refusal"
+                    or $en == "claude_code.internal_error") then "FAILURE"
+                elif ($r["success"] != null) then (if truthy($r["success"]) then "SUCCESS" else "FAILURE" end)
+                elif ($r["status"] == "failed") then "FAILURE"
+                else "SUCCESS" end ) as $outcome
+            | ( if $en == "claude_code.internal_error" then 7
+                elif ($outcome == "FAILURE") then 6
+                elif $en == "claude_code.auth" then 4
+                else 2 end ) as $sev
+            | (($r["input_tokens"] // 0) + ($r["output_tokens"] // 0)
+               + ($r["cache_read_tokens"] // 0) + ($r["cache_creation_tokens"] // 0)) as $total_tokens
+
+            | { _cef: {
+                  vendor: "Anthropic",
+                  product: "Claude Code",
+                  version: (($r["app.version"]) // ($r["service.version"]) // ""),
+                  signature_id: $en,
+                  name: ($en | ltrimstr("claude_code.")),
+                  severity: $sev,
+                  extension: ( {
+                    rt: $rt,
+                    suser: $r["user.email"],
+                    suid: ($r["user.account_uuid"] // $r["user.id"]),
+                    dhost: $r["terminal.type"],
+                    act: ($en | ltrimstr("claude_code.")),
+                    outcome: $outcome,
+                    app: "claude-code",
+                    dvchost: $r["terminal.type"],
+                    reason: ($r["error"] // $r["error_type"] // $r["error_category"]),
+                    externalId: $r["request_id"],
+                    # --- custom slots (each paired with its *Label) ---
+                    cs1Label: "model",            cs1: $r["model"],
+                    cs2Label: "sessionId",        cs2: $r["session.id"],
+                    cs3Label: "organizationId",   cs3: $r["organization.id"],
+                    cs4Label: "querySource",      cs4: $r["query_source"],
+                    cn1Label: "inputTokens",      cn1: $r["input_tokens"],
+                    cn2Label: "outputTokens",     cn2: $r["output_tokens"],
+                    cn3Label: "totalTokens",      cn3: (if $total_tokens > 0 then $total_tokens else null end),
+                    cfp1Label: "costUsd",         cfp1: $r["cost_usd"],
+                    flexNumber1Label: "durationMs", flexNumber1: $r["duration_ms"]
+                  } | with_entries(select(.value != null and .value != "")) )
+              } }
+          ][0]

--- a/cef/v0/anthropic/anthropic-compliance-activities.yaml
+++ b/cef/v0/anthropic/anthropic-compliance-activities.yaml
@@ -1,0 +1,73 @@
+name: "Anthropic Compliance Activities to CEF"
+description: "Maps Anthropic Claude Compliance API activity-feed records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "anthropic-compliance-activities"
+tags:
+  - "v0"
+  - "cef"
+  - "anthropic"
+  - "compliance-activities"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Anthropic Claude Compliance API activity feed -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Emit FINAL-FORM values: severity int 0-10, times epoch-MILLISECONDS,
+          # every cs* slot paired with its cs*Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.actor // {}) as $a
+          | ($a.email_address // $a.unauthenticated_email_address) as $email
+          | ($a.user_id // $a.api_key_id // $a.admin_api_key_id // $a.directory_id) as $auid
+          | ($r.type // "") as $t
+          | ($t | ascii_downcase) as $tl
+          | (def has($s): ($tl | contains($s));
+             (has("failed") or has("denied") or has("rejected")
+              or has("blocked") or has("error"))) as $fail
+          | (def has($s): ($tl | contains($s));
+             if $fail then 7
+             elif (has("deleted") or has("removed") or has("revoked") or has("archived")) then 5
+             else 2 end) as $severity
+          | ($t | gsub("_"; " ")) as $nm
+          | {
+              _cef: {
+                vendor: "Anthropic",
+                product: "Claude Compliance API",
+                version: "",
+                signature_id: $t,
+                name: (if ($nm | length) > 0 then (($nm[0:1] | ascii_upcase) + $nm[1:]) else "Compliance activity" end),
+                severity: $severity,
+                extension: (
+                  {
+                    rt: to_epoch_ms($r.created_at),
+                    externalId: $r.id,
+                    suser: $email,
+                    suid: $auid,
+                    src: $a.ip_address,
+                    requestClientApplication: $a.user_agent,
+                    act: $r.type,
+                    outcome: (if $fail then "FAILURE" else "SUCCESS" end)
+                  }
+                  + (if $r.organization_id then { cs1Label: "organizationId", cs1: $r.organization_id } else {} end)
+                  + (if $r.claude_chat_id then { cs2Label: "chatId", cs2: $r.claude_chat_id } else {} end)
+                  + (if $r.claude_project_id then { cs3Label: "projectId", cs3: $r.claude_project_id } else {} end)
+                  + (if $a.type then { cs4Label: "actorType", cs4: $a.type } else {} end)
+                  + (if $r.organization_uuid then { cs5Label: "organizationUuid", cs5: $r.organization_uuid } else {} end)
+                  + (if $a.directory_id then { cs6Label: "scimDirectoryId", cs6: $a.directory_id } else {} end)
+                  | with_entries(select(.value != null and .value != ""))
+                )
+              }
+            }

--- a/cef/v0/anthropic/anthropic-compliance-organizations.yaml
+++ b/cef/v0/anthropic/anthropic-compliance-organizations.yaml
@@ -1,0 +1,54 @@
+name: "Anthropic Compliance Organizations to CEF"
+description: "Maps Anthropic Compliance API organization directory records (List organizations endpoint) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "anthropic-compliance-organizations"
+tags:
+  - "v0"
+  - "cef"
+  - "anthropic"
+  - "compliance"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Anthropic Compliance API - List organizations -> CEF intermediate (T1)
+          # One organization record in -> one {_cef:{...}} object out.
+          # No escaping here — the shared CEF Serializer (T2) owns all escaping.
+          # Emit FINAL-FORM values: severity 0-10, times epoch-MILLISECONDS,
+          # custom slots cs*/cn* paired with their *Label.
+          #
+          # Source fields (all documented): uuid, name, created_at.
+          #   uuid       -> cs1 (organizationUuid)
+          #   name       -> cs2 (organizationName)  + Name header
+          #   created_at -> rt (epoch-ms; organization creation time)
+          # Directory snapshot => informational severity (2).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          . as $r
+          | { _cef: {
+              vendor: "Anthropic",
+              product: "Claude Compliance API",
+              version: "",
+              signature_id: "compliance.organization",
+              name: ("Organization directory record: " + ($r.name // $r.uuid // "unknown")),
+              severity: 2,
+              extension: ( {
+                rt:       to_epoch_ms($r.created_at),
+                act:      "organization-snapshot",
+                outcome:  "SUCCESS",
+                cs1Label: "organizationUuid",
+                cs1:      $r.uuid,
+                cs2Label: "organizationName",
+                cs2:      $r.name
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/anthropic/anthropic-compliance-users.yaml
+++ b/cef/v0/anthropic/anthropic-compliance-users.yaml
@@ -1,0 +1,54 @@
+name: "Anthropic Compliance Users to CEF"
+description: "Maps Anthropic Compliance API organization-user directory records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "anthropic-compliance-users"
+tags:
+  - "v0"
+  - "cef"
+  - "anthropic"
+  - "users"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Anthropic Compliance API — organization users -> CEF intermediate (T1)
+          # Source: GET /v1/compliance/organizations/{org_uuid}/users
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values: severity 0-10, times epoch-ms,
+          # every cs* slot paired with its *Label. One jq pass, shallow null-drop.
+          #
+          # Documented fields: id, full_name, email, organization_role,
+          # created_at (+ organization_uuid from the same Compliance API).
+          # A user directory record is informational -> severity 2.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | { _cef: {
+              vendor: "Anthropic",
+              product: "Claude Compliance API",
+              version: "",
+              signature_id: "compliance.organization.users",
+              name: "Organization user directory record",
+              severity: 2,
+              extension: ( {
+                rt:      to_epoch_ms($r.created_at),
+                suser:   $r.email,
+                suid:    $r.id,
+                act:     "user-listed",
+                outcome: "SUCCESS",
+                cs1Label: "organizationRole", cs1: $r.organization_role,
+                cs2Label: "fullName",         cs2: $r.full_name,
+                cs3Label: "organizationUuid", cs3: $r.organization_uuid
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/anthropic/anthropic-groups.yaml
+++ b/cef/v0/anthropic/anthropic-groups.yaml
@@ -1,0 +1,56 @@
+name: "Anthropic Claude Enterprise Groups to CEF"
+description: "Maps Anthropic Claude Enterprise RBAC/SCIM group directory records (Admin/Compliance API groups endpoint) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "anthropic-groups"
+tags:
+  - "v0"
+  - "cef"
+  - "anthropic"
+  - "groups"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Anthropic Claude Enterprise group directory record -> CEF T1.
+          # Input: one group record per invocation:
+          #   { id, name, description, source_type("direct"|"scim"),
+          #     roles[], created_at, updated_at }
+          # No escaping here — the shared CEF Serializer (T2) owns it.
+          # Times emitted as epoch-MILLISECONDS; custom cs* slots paired
+          # with their *Label; one jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          . as $r
+          | (($r.roles // []) | map(select(. != null and . != "")) | join(",")) as $rolestr
+          | { _cef: {
+              vendor: "Anthropic",
+              product: "Claude Enterprise",
+              version: "",
+              signature_id: "rbac_group.snapshot",
+              name: (($r.name // "group") + " group (" + ($r.source_type // "direct") + ")"),
+              severity: 2,
+              # Each custom cs* slot is added with its *Label as a pair, and only
+              # when the source value is present, so a label never orphans.
+              extension: ( (
+                { rt:   (to_epoch_ms($r.updated_at) // to_epoch_ms($r.created_at)),
+                  act:  "group-directory-snapshot",
+                  outcome: "SUCCESS",
+                  deviceCustomDate1Label: "groupCreated",
+                  deviceCustomDate1: to_epoch_ms($r.created_at) }
+                + (if ($r.id // "") != ""          then { cs1Label: "groupId",     cs1: $r.id } else {} end)
+                + (if ($r.name // "") != ""        then { cs2Label: "groupName",   cs2: $r.name } else {} end)
+                + (if ($r.source_type // "") != "" then { cs3Label: "sourceType",  cs3: $r.source_type } else {} end)
+                + (if $rolestr != ""               then { cs4Label: "roles",       cs4: $rolestr } else {} end)
+                + (if ($r.description // "") != ""  then { cs5Label: "description", cs5: $r.description } else {} end)
+              ) | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/anthropic/anthropic-projects.yaml
+++ b/cef/v0/anthropic/anthropic-projects.yaml
@@ -1,0 +1,60 @@
+name: "Anthropic Projects to CEF"
+description: "Maps Anthropic (Claude) Projects records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "anthropic-projects"
+tags:
+  - "v0"
+  - "cef"
+  - "anthropic"
+  - "projects"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Anthropic (Claude) Projects -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping. Emit FINAL-FORM values: severity int 0-10, times as
+          # epoch-MILLISECONDS, every custom slot paired with its *Label.
+          # One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.details // {}) as $d
+          | ($r.user // $d.user // {}) as $u
+          | ($r.organization_id // $d.organization_id) as $org
+          | (if ($r.is_private != null) then $r.is_private else $d.is_private end) as $priv
+          | ($r.name // $d.name) as $pname
+
+          | { _cef: {
+              vendor: "Anthropic",
+              product: "Claude Projects",
+              version: "",
+              signature_id: "anthropic.project",
+              name: ("Claude project: " + ($pname // $r.id // $d.id // "unknown")),
+              severity: 2,
+              extension: ( {
+                rt:    to_epoch_ms($d.updated_at // $r.updated_at // $r.created_at),
+                start: to_epoch_ms($r.created_at // $d.created_at),
+                end:   to_epoch_ms($d.updated_at // $r.updated_at),
+                suser: $u.email_address,
+                suid:  $u.id,
+                externalId: ($r.id // $d.id),
+                msg:   $d.description,
+                cs1Label: "organizationId", cs1: $org,
+                cs2Label: "projectName",    cs2: $pname,
+                cs3Label: "isPrivate",      cs3: (if $priv == null then null else ($priv | tostring) end),
+                cn1Label: "chatsCount",     cn1: $d.chats_count,
+                cn2Label: "attachmentsCount", cn2: ($d.attachments_count // (($r.attachments // []) | length))
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/anthropic/anthropic-roles.yaml
+++ b/cef/v0/anthropic/anthropic-roles.yaml
@@ -1,0 +1,54 @@
+name: "Anthropic Organization Roles to CEF"
+description: "Maps Anthropic Admin API organization user/role records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "anthropic-roles"
+tags:
+  - "v0"
+  - "cef"
+  - "anthropic"
+  - "roles"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Anthropic Admin API organization user/role -> CEF intermediate (T1).
+          # Input: one org user record (GET /v1/organizations/users):
+          #   { id, added_at, email, name, role, type }
+          # No escaping here — the shared CEF Serializer (T2) owns it.
+          # Severity buckets by org role privilege; rt is epoch-MILLISECONDS.
+          # One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          . as $r
+          | ($r.role // "user") as $role
+          | { _cef: {
+              vendor: "Anthropic",
+              product: "Anthropic Admin API",
+              version: "",
+              signature_id: "organization.user.role",
+              name: ("Organization member role: " + $role),
+              # Privileged org roles rank higher on the 0-10 CEF scale.
+              severity: ( { "primary_owner": 8, "owner": 8, "admin": 7,
+                            "membership_admin": 7, "billing": 5, "developer": 4,
+                            "claude_code_user": 3, "managed": 3, "user": 3 }[$role] // 3 ),
+              extension: ( {
+                rt:      to_epoch_ms($r.added_at),
+                suser:   $r.email,
+                suid:    $r.id,
+                outcome: "SUCCESS",
+                msg:     (($r.name // $r.email // "user") + " has organization role " + $role),
+                cs1Label: "role",     cs1: $role,
+                cs2Label: "userType", cs2: ($r.type // null),
+                cs3Label: "fullName", cs3: ($r.name // null)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/apple-business/apple-business-audit-events.yaml
+++ b/cef/v0/apple-business/apple-business-audit-events.yaml
@@ -1,0 +1,63 @@
+name: "Apple Business Manager Audit Events to CEF"
+description: "Maps Apple Business Manager audit events into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "apple-business-audit-events"
+tags:
+  - "v0"
+  - "cef"
+  - "apple-business"
+  - "audit-events"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Apple Business Manager auditEvents -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # severity: integer 0-10; rt: epoch-MILLISECONDS; custom slots
+          # paired with their *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+              if $ts == null then null
+              elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+              else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000) end;
+
+          . as $r
+          | ($r.attributes // {}) as $a
+          | ($a.type // "") as $t
+          | ($a.subjectType // "" | ascii_upcase) as $st
+          | ($a.eventDataDeviceAddedToOrg // $a.eventDataDeviceRemovedFromOrg
+             // $a.eventDataDeviceAssignedToServer // $a.eventDataDeviceUnassignedFromServer
+             // $a.eventDataDeviceIsErased // {}) as $devdata
+
+          | { _cef: {
+              vendor: "Apple",
+              product: "Apple Business Manager",
+              version: "",
+              signature_id: $t,
+              name: (($t | gsub("_"; " ") | ascii_downcase) + " (" + ($a.category // "audit") + ")"),
+              severity: (
+                if ($a.outcome // "" | ascii_upcase) == "FAILURE" then 7 else 3 end),
+              extension: ( {
+                rt:         to_epoch_ms($a.eventDateTime),
+                externalId: $r.id,
+                act:        $t,
+                cat:        $a.category,
+                outcome:    $a.outcome,
+                suser:      $a.actorName,
+                suid:       $a.actorId,
+                duser:      (if $st == "USER" or $st == "ACCOUNT" or $st == "API_ACCOUNT" then $a.subjectName else null end),
+                duid:       $a.subjectId,
+                deviceExternalId: (if $st == "DEVICE" then $a.subjectId else null end),
+                msg:        (($a.actorName // "actor") + " " + $t + " on " + ($a.subjectName // ($a.subjectType // "resource"))),
+                cs1Label: "subjectType",  cs1: $a.subjectType,
+                cs2Label: "actorType",    cs2: $a.actorType,
+                cs3Label: "serialNumber", cs3: $devdata.serialNumber,
+                cs4Label: "groupId",      cs4: $a.groupId
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/arize/arize-audit-logs.yaml
+++ b/cef/v0/arize/arize-audit-logs.yaml
@@ -1,0 +1,57 @@
+name: "Arize Audit Logs to CEF"
+description: "Maps Arize AX audit log records (authenticated GraphQL mutations / login attempts) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "arize-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "arize"
+  - "audit-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Arize AX audit logs -> CEF intermediate (T1). No escaping here;
+          # the shared CEF Serializer (T2) owns all escaping/header assembly.
+          # Emit final-form values: severity int 0-10, times epoch-MS,
+          # custom cs* slots paired with their *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.user // {}) as $u
+          | (($r.operationName // $r.mutationName) // "") as $op
+          | ($r.success) as $ok
+          | { _cef: {
+              vendor: "Arize",
+              product: "Arize AX",
+              version: "",
+              signature_id: $op,
+              name: ("Arize AX operation: " + $op),
+              # Successful audit ops are informational (3); failures are
+              # elevated (7).
+              severity: (if $ok == false then 7 else 3 end),
+              extension: ( {
+                rt:      to_epoch_ms($r.loggedAt),
+                suser:   ($u.email // $u.name),
+                suid:    $u.id,
+                src:     $r.ip,
+                act:     $op,
+                outcome: (if $ok == true then "SUCCESS" elif $ok == false then "FAILURE" else null end),
+                externalId: $r.id,
+                cs1Label: "space",       cs1: $r.spaceName,
+                cs2Label: "accountName", cs2: $r.accountName,
+                cs3Label: "operationText", cs3: $r.operationText,
+                cs4Label: "variables",   cs4: (if $r.variables != null then ($r.variables | tojson) else null end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/atlassian/atlassian-confluence-audit-logs.yaml
+++ b/cef/v0/atlassian/atlassian-confluence-audit-logs.yaml
@@ -1,0 +1,63 @@
+name: "Atlassian Confluence Audit Logs to CEF"
+description: "Maps Atlassian Confluence audit log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "atlassian-confluence-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "atlassian"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Atlassian Confluence Audit Logs -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Emits final-form values: severity int 0-10, times epoch-ms,
+          # custom cs* slots paired with their *Label. One jq pass; shallow
+          # null-drop on the extension object (no recursive walk).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          def lc($s): ($s // "") | ascii_downcase;
+
+          . as $r
+          | ($r.author // {}) as $au
+          | (lc($r.category)) as $cat
+          # Admin/permission/user-management categories are more security-
+          # relevant; bump their severity bucket.
+          | ( if   ($cat | test("permission|security|user|group|admin")) then 6
+              elif ($r.sysAdmin == true or $r.superAdmin == true) then 5
+              else 3 end ) as $sev
+          | { _cef: {
+              vendor: "Atlassian",
+              product: "Confluence",
+              version: "",
+              signature_id: ($r.category // "Audit"),
+              name: ($r.summary // "Confluence audit event"),
+              severity: $sev,
+              extension: ( {
+                rt:      to_epoch_ms($r.creationDate),
+                suser:   ($au.displayName // $au.publicName),
+                suid:    $au.accountId,
+                src:     $r.remoteAddress,
+                act:     $r.summary,
+                cat:     $r.category,
+                msg:     ($r.description // $r.summary),
+                outcome: "SUCCESS",
+                cs1Label: "affectedObjectName", cs1: $r.affectedObject.name,
+                cs2Label: "affectedObjectType", cs2: $r.affectedObject.objectType,
+                cs3Label: "changedValues",      cs3: ($r.changedValues | if . == null then null else tojson end),
+                cs4Label: "sysAdmin",           cs4: ($r.sysAdmin | if . == null then null else tostring end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/atlassian/atlassian-jira-roles.yaml
+++ b/cef/v0/atlassian/atlassian-jira-roles.yaml
@@ -1,0 +1,64 @@
+name: "Atlassian Jira Project Roles to CEF"
+description: "Maps Atlassian Jira project-role membership records (atlassian-jira-roles) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+# author is ALWAYS "Monad" — never a person. You are a contributor.
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "atlassian-jira-roles"
+tags:
+  - "v0"
+  - "cef"
+  - "atlassian"
+  - "roles"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Atlassian Jira ProjectRole (atlassian-jira-roles) -> CEF T1.
+          # Emits the normalized {_cef:{...}} intermediate; NO escaping here
+          # (the shared CEF Serializer / T2 owns all escaping). Final-form
+          # values only: severity int 0-10, times epoch-MILLISECONDS, every
+          # cs*/cn* slot paired with its *Label. One jq pass; shallow
+          # null-drop on the extension object (no recursive walk).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.actors // []) as $actors
+          | ($r.scope.project // {}) as $proj
+          | { _cef: {
+              vendor: "Atlassian",
+              product: "Jira",
+              version: "",
+              signature_id: "jira.project.role.membership",
+              name: ("Jira project role membership: " + ($r.name // "unknown")),
+              # Admin-bearing roles carry higher weight than ordinary roles.
+              severity: (if $r.admin == true then 6 else 3 end),
+              # Build cs*/cn* slots as whole label+value pairs, added only
+              # when the value exists, so a dropped value never orphans its
+              # *Label. One pass; shallow null-drop closes out rt/act/outcome.
+              extension: (
+                {
+                  rt:      (to_epoch_ms($r.collected_at) // ((now * 1000) | floor)),
+                  act:     "project-role-membership",
+                  outcome: "SUCCESS"
+                }
+                + (if $r.name != null       then { cs1Label: "roleName",    cs1: $r.name }       else {} end)
+                + (if $r.id != null         then { cn1Label: "roleId",      cn1: $r.id }         else {} end)
+                + (if $proj.key != null     then { cs2Label: "projectKey",  cs2: $proj.key }     else {} end)
+                + (if $proj.name != null    then { cs3Label: "projectName", cs3: $proj.name }    else {} end)
+                + ( ($actors | map(.actorUser.accountId // .actorGroup.name // .displayName) | join(",")) as $m
+                    | if $m != "" then { cs4Label: "roleMembers", cs4: $m } else {} end )
+                + { cn2Label: "memberCount", cn2: ($actors | length) }
+                + (if $r.description != null then { cs5Label: "roleDescription", cs5: $r.description } else {} end)
+                | with_entries(select(.value != null and .value != ""))
+              )
+          } }

--- a/cef/v0/atlassian/atlassian-jira-users.yaml
+++ b/cef/v0/atlassian/atlassian-jira-users.yaml
@@ -1,0 +1,62 @@
+name: "Atlassian Jira Users to CEF"
+description: "Maps Atlassian Jira Cloud user directory records (from the atlassian-jira-users input) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "atlassian-jira-users"
+tags:
+  - "v0"
+  - "cef"
+  - "atlassian"
+  - "jira"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Atlassian Jira Users -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2)
+          # owns all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (active user = 3, inactive = 5)
+          #   - rt: epoch-MILLISECONDS (collection time; a Jira user record
+          #         carries no timestamp of its own)
+          #   - custom slots cs*/cn* ALWAYS paired with their *Label
+          # One jq pass, per-record only; shallow with_entries null-drop.
+          # ---------------------------------------------------------------
+          . as $r
+          | ($r.emailAddress // "") as $email
+          | ($r.active == true) as $is_active
+          | (($r.groups.items // []) | map(.name) | map(select(. != null))) as $groupnames
+          | (($r.applicationRoles.items // []) | map(.name // .key) | map(select(. != null))) as $roles
+          | { _cef: {
+              vendor: "Atlassian",
+              product: "Jira",
+              version: "",
+              signature_id: ("jira.user." + (if $is_active then "active" else "inactive" end)),
+              name: ("Jira user directory entry: " + ($r.displayName // $email // $r.accountId)),
+              severity: (if $is_active then 3 else 5 end),
+              extension: ( {
+                rt:        ((now | floor) * 1000),
+                duser:     ($r.displayName // $email),
+                duid:      $r.accountId,
+                dvchost:   "jira",
+                outcome:   (if $is_active then "Active" else "Inactive" end),
+                cs1Label:  "accountType",
+                cs1:       $r.accountType,
+                cs2Label:  "emailAddress",
+                cs2:       (if $email != "" then $email else null end),
+                cs3Label:  "groups",
+                cs3:       (if ($groupnames | length) > 0 then ($groupnames | join(",")) else null end),
+                cs4Label:  "applicationRoles",
+                cs4:       (if ($roles | length) > 0 then ($roles | join(",")) else null end),
+                cs5Label:  "timeZone",
+                cs5:       $r.timeZone,
+                cs6Label:  "locale",
+                cs6:       $r.locale,
+                cn1Label:  "active",
+                cn1:       (if $is_active then 1 else 0 end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-cognito-users.yaml
+++ b/cef/v0/aws/aws-cognito-users.yaml
@@ -1,0 +1,76 @@
+name: "AWS Cognito Users to CEF"
+description: "Maps AWS Cognito user-pool user records (ListUsers UserType) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-cognito-users"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "cognito"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Cognito Users -> CEF intermediate (T1).
+          # Input: one Cognito user-pool user record (ListUsers UserType)
+          #   from the Monad `aws-cognito-users` connector.
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values (severity 0-10; times
+          # epoch-MILLISECONDS; every cs*/cn* slot paired with its *Label).
+          # One jq pass; shallow null-drop on `extension`; no recursive walk.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number"
+              then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          def truthy($v):
+            ($v == true) or (($v | type) == "string" and ($v | ascii_downcase) == "true");
+
+          . as $r
+          | ( ( $r.Attributes // [] )
+              | map(select(.Name != null))
+              | map({ (.Name): .Value }) | add // {} ) as $a
+          | ( $a["email"] ) as $email
+          | ( $a["sub"] // $r.Username ) as $uid
+          | ( $r.UserStatus // "UNKNOWN" ) as $status
+          | ( (( $r.MFAOptions // [] ) | length) > 0 ) as $has_mfa
+          | ( if ($r.Enabled != null) then truthy($r.Enabled) else true end ) as $enabled
+
+          | { _cef: {
+              vendor: "Amazon",
+              product: "AWS Cognito",
+              version: "",
+              signature_id: "cognito-user-inventory",
+              name: ("AWS Cognito user inventory: " + ($r.Username // "unknown")),
+              # Inventory is informational; escalate for risky account states.
+              severity: (
+                if ($status == "COMPROMISED") then 9
+                elif ($enabled | not) then 5
+                elif ($status == "RESET_REQUIRED" or $status == "FORCE_CHANGE_PASSWORD") then 4
+                else 2 end
+              ),
+              extension: ( {
+                rt:      to_epoch_ms($r.UserLastModifiedDate // $r.UserCreateDate),
+                end:     to_epoch_ms($r.UserLastModifiedDate),
+                start:   to_epoch_ms($r.UserCreateDate),
+                suser:   ($email // $r.Username),
+                suid:    $uid,
+                act:     "user-inventory",
+                outcome: (if $enabled then "SUCCESS" else "FAILURE" end),
+                cs1Label: "userStatus",           cs1: $status,
+                cs2Label: "enabled",              cs2: ($enabled | tostring),
+                cs3Label: "mfaEnabled",           cs3: ($has_mfa | tostring),
+                cs4Label: "emailVerified",        cs4: $a["email_verified"],
+                cs5Label: "preferredUsername",    cs5: $a["preferred_username"],
+                cs6Label: "phoneNumber",          cs6: $a["phone_number"]
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-config-inventory.yaml
+++ b/cef/v0/aws/aws-config-inventory.yaml
@@ -1,0 +1,71 @@
+name: "AWS Config Resource Inventory to CEF"
+description: "Maps AWS Config configuration item records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-config-inventory"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "config"
+  - "inventory"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Config configuration item -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Values are FINAL FORM: severity integer 0-10, times epoch-ms,
+          # every cs*/cn* slot paired with its *Label. One jq pass; shallow
+          # null-drop on the extension object.
+          #
+          #   signature_id = .resourceType  (stable, low cardinality)
+          #   name         = human sentence about the inventoried resource
+          #   severity     = 2 (informational inventory) / 5 when not recorded
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ( $r.configuration // {} ) as $cfg
+          | ( $r.configurationItemStatus // "" ) as $ci_status
+          | ( if ($ci_status | test("NotRecorded|Deleted")) then 5 else 2 end ) as $sev
+          | ( if ($ci_status | test("NotRecorded|DeletedNotRecorded"))
+              then "FAILURE" else "SUCCESS" end ) as $outcome
+          | ( ($cfg.publicIpAddress // $cfg.privateIpAddress) ) as $ip
+          | ( if ($r.tags | type) == "object"
+              then ( $r.tags | to_entries | map(.key + "=" + (.value | tostring)) | join(",") )
+              else null end ) as $tags_str
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "AWS Config",
+              version: ($r.version // ""),
+              signature_id: ($r.resourceType // "AWS::Resource"),
+              name: ( "AWS Config inventory: " + ($r.resourceType // "resource")
+                      + " " + ($r.resourceId // "") ),
+              severity: $sev,
+              extension: ( {
+                rt:      to_epoch_ms($r.configurationItemCaptureTime),
+                deviceExternalId: $r.resourceId,
+                dvchost: $r.resourceName,
+                src:     $ip,
+                act:     "inventory",
+                outcome: $outcome,
+                externalId: $r.configurationStateId,
+                cs1Label: "resourceType",  cs1: $r.resourceType,
+                cs2Label: "resourceArn",   cs2: $r.arn,
+                cs3Label: "awsRegion",     cs3: $r.awsRegion,
+                cs4Label: "accountId",     cs4: $r.accountId,
+                cs5Label: "itemStatus",    cs5: ($ci_status | select(. != "")),
+                cs6Label: "tags",          cs6: $tags_str
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-eks-audit-logs.yaml
+++ b/cef/v0/aws/aws-eks-audit-logs.yaml
@@ -1,0 +1,92 @@
+name: "AWS EKS Audit Logs to CEF"
+description: "Maps Amazon EKS (Kubernetes API server) audit.k8s.io/v1 audit records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-eks-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "eks-audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Amazon EKS Kubernetes audit (audit.k8s.io/v1) -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values: severity int 0-10, times as
+          # epoch-MILLISECONDS, every cs* slot paired with its *Label.
+          # One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ( $r.user // {} )           as $u
+          | ( $r.objectRef // {} )      as $obj
+          | ( $r.responseStatus // {} ) as $rs
+          | ( $r.annotations // {} )    as $ann
+          | ( $r.verb // "" )           as $verb
+          | ( ($r.sourceIPs // []) | .[0] ) as $src_ip
+          | ( $rs.code // null )        as $code
+          | ( $ann["authorization.k8s.io/decision"] // null ) as $decision
+
+          # Outcome + severity. A forbidden call (RBAC deny) or an HTTP >= 400
+          # response is the security-relevant case, so it scores higher.
+          | ( if ($decision == "forbid") or ($code != null and $code >= 400)
+              then "Failure" else "Success" end ) as $outcome
+          | ( if $decision == "forbid" then 7
+              elif ($code != null and $code >= 500) then 6
+              elif ($code != null and $code >= 400) then 5
+              else 2 end ) as $severity
+
+          # A compact, low-cardinality signature: verb + resource kind
+          # (e.g. "create:pods", "delete:secrets"). Falls back to the verb.
+          | ( if ($obj.resource // "") != "" then ($verb + ":" + $obj.resource) else $verb end ) as $sig
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "Amazon EKS Kubernetes Audit",
+              version: ( $r.apiVersion // "" ),
+              signature_id: $sig,
+              name: ( "Kubernetes API " + $verb
+                      + ( if ($obj.resource // "") != "" then " " + $obj.resource else "" end )
+                      + ( if ($obj.name // "") != "" then " " + $obj.name else "" end ) ),
+              severity: $severity,
+              extension: ( {
+                rt:        to_epoch_ms($r.requestReceivedTimestamp),
+                end:       to_epoch_ms($r.stageTimestamp),
+                suser:     $u.username,
+                src:       $src_ip,
+                act:       $verb,
+                request:   $r.requestURI,
+                requestMethod: $verb,
+                requestClientApplication: $r.userAgent,
+                outcome:   $outcome,
+                app:       ( $obj.apiVersion // null ),
+                reason:    ( $ann["authorization.k8s.io/reason"] ),
+                msg:       ( $rs.reason // $rs.status ),
+                cn1:       ( if $code != null then $code else null end ),
+                cn1Label:  "httpResponseCode",
+                cs1:       $u.uid,
+                cs1Label:  "k8sUserUid",
+                cs2:       $obj.namespace,
+                cs2Label:  "k8sNamespace",
+                cs3:       $obj.resource,
+                cs3Label:  "k8sResource",
+                cs4:       $obj.name,
+                cs4Label:  "k8sObjectName",
+                cs5:       ( ($u.groups // []) | join(",") ),
+                cs5Label:  "k8sUserGroups",
+                cs6:       $r.auditID,
+                cs6Label:  "auditID"
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-iam-access-analyzer.yaml
+++ b/cef/v0/aws/aws-iam-access-analyzer.yaml
@@ -1,0 +1,72 @@
+name: "AWS IAM Access Analyzer Findings to CEF"
+description: "Maps AWS IAM Access Analyzer external-access finding records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-iam-access-analyzer"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "access-analyzer"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS IAM Access Analyzer Finding -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping. Emit FINAL-FORM values: severity int 0-10, times in
+          # epoch-MILLISECONDS, every cs*/cn* slot paired with its *Label.
+          # One jq pass; shallow null-drop on the extension object only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ( $r.status // "ACTIVE" ) as $status
+          | ( [ ($r.principal // {}) | to_entries[] | .value ] | join(",") ) as $principal_str
+          | ( ($r.action // []) | join(",") ) as $actions_str
+          | ( ($r.analyzerArn // "") | split(":") ) as $aarn
+          | ( if ($aarn | length) > 3 and ($aarn[3] != "") then $aarn[3] else null end ) as $region
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "IAM Access Analyzer",
+              version: "",
+              signature_id: "iam-access-analyzer.external-access",
+              name: ("External access to " + ($r.resourceType // "resource") + " " + ($r.resource // $r.id)),
+              # Public exposure = 8, scoped external access = 5, closed = 3.
+              severity: ( if ($status == "RESOLVED" or $status == "ARCHIVED") then 3
+                          elif ($r.isPublic // false) == true then 8
+                          else 5 end ),
+              extension: ( {
+                rt:         to_epoch_ms($r.analyzedAt),
+                start:      to_epoch_ms($r.createdAt),
+                end:        to_epoch_ms($r.updatedAt),
+                externalId: $r.id,
+                suser:      (if $principal_str == "" then null else $principal_str end),
+                act:        $status,
+                outcome:    (if ($status == "RESOLVED") then "RESOLVED"
+                             elif ($status == "ARCHIVED") then "ARCHIVED"
+                             else "ACTIVE" end),
+                msg:        (if ($r.error // null) != null
+                             then ("Access Analyzer finding error: " + $r.error)
+                             else ("External access finding for " + ($r.resource // $r.id)) end),
+                # Resource identity + finding detail into custom string slots.
+                cs1Label: "resource",        cs1: $r.resource,
+                cs2Label: "resourceType",    cs2: $r.resourceType,
+                cs3Label: "resourceOwnerAccount", cs3: $r.resourceOwnerAccount,
+                cs4Label: "awsRegion",       cs4: $region,
+                cs5Label: "grantedActions",  cs5: (if $actions_str == "" then null else $actions_str end),
+                cs6Label: "analyzerArn",     cs6: $r.analyzerArn,
+                # isPublic as a numeric flag (1/0).
+                cn1Label: "isPublic",        cn1: (if ($r.isPublic // false) == true then 1 else 0 end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-iam-aliases.yaml
+++ b/cef/v0/aws/aws-iam-aliases.yaml
@@ -1,0 +1,51 @@
+name: "AWS IAM Account Aliases to CEF"
+description: "Maps AWS IAM account-alias inventory records (an AWS account and its IAM account alias) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-iam-aliases"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "iam-aliases"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS IAM Account Aliases -> CEF intermediate (T1).
+          # Input: one aws-iam-aliases record per invocation, shape:
+          #   { "AccountID": "123456789012", "Alias": "acme-production" }
+          #
+          # Inventory snapshot (no event time, no severity in source):
+          #   severity = 1 (informational inventory record)
+          #   rt       = collection time (now, epoch-ms); source has none
+          #   AccountID -> cs2 (awsAccountId)
+          #   Alias     -> cs1 (accountAlias)
+          # Do NOT escape here — the shared CEF Serializer (T2) owns escaping.
+          # ---------------------------------------------------------------
+
+          . as $r
+          | ($r.AccountID // null) as $acct
+          | ($r.Alias // null) as $alias
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "AWS IAM",
+              version: "",
+              signature_id: "iam.account.alias",
+              name: "AWS account alias inventory",
+              severity: 1,
+              extension: ( {
+                rt:         (now * 1000 | floor),
+                cs1Label:   "accountAlias",
+                cs1:        $alias,
+                cs2Label:   "awsAccountId",
+                cs2:        $acct,
+                outcome:    "SUCCESS"
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-inspector.yaml
+++ b/cef/v0/aws/aws-inspector.yaml
@@ -1,0 +1,72 @@
+name: "AWS Inspector Findings to CEF"
+description: "Maps AWS Inspector (Inspector2) finding records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-inspector"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "inspector"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Inspector (Inspector2) Finding -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping/header assembly. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (mapped from Inspector severity)
+          #   - time fields (rt/start/end): epoch-MILLISECONDS
+          #   - custom cs*/cn* slots ALWAYS paired with their *Label
+          # One jq pass; shallow with_entries null-drop on extension.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number"
+              then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ( $r.packageVulnerabilityDetails // {} ) as $pvd
+          | ( ($r.resources // [])[0] // {} ) as $r0
+          | ( $r0.details.awsEc2Instance // {} ) as $ec2
+          | ( ($pvd.cvss // []) | (.[0] // {}) ) as $cvss0
+
+          # Inspector severity -> CEF severity bucket 0-10
+          | ( { "INFORMATIONAL": 1, "LOW": 3, "MEDIUM": 5,
+                "HIGH": 8, "CRITICAL": 10, "UNTRIAGED": 0 }[$r.severity] // 0 ) as $sev
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "Amazon Inspector",
+              version: "",
+              signature_id: ( $pvd.vulnerabilityId // $r.type ),
+              name: ( $r.title // $r.description // "AWS Inspector finding" ),
+              severity: $sev,
+              extension: ( {
+                rt:         to_epoch_ms($r.updatedAt // $r.lastObservedAt // $r.firstObservedAt),
+                start:      to_epoch_ms($r.firstObservedAt),
+                end:        to_epoch_ms($r.lastObservedAt),
+                msg:        $r.description,
+                externalId: $r.findingArn,
+                outcome:    $r.status,
+                cat:        $r.type,
+                dvchost:    $r0.id,
+                src:        ( ($ec2.ipV4Addresses // [])[0] ),
+                cs1Label: "cveId",           cs1: $pvd.vulnerabilityId,
+                cs2Label: "awsAccountId",    cs2: $r.awsAccountId,
+                cs3Label: "awsRegion",       cs3: $r0.region,
+                cs4Label: "resourceId",      cs4: $r0.id,
+                cs5Label: "fixAvailable",    cs5: $r.fixAvailable,
+                cs6Label: "exploitAvailable", cs6: $r.exploitAvailable,
+                cn1Label: "inspectorScore",  cn1: $r.inspectorScore,
+                cn2Label: "cvssBaseScore",   cn2: $cvss0.baseScore,
+                cfp1Label: "epssScore",      cfp1: ($r.epss.score // null)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-kms.yaml
+++ b/cef/v0/aws/aws-kms.yaml
@@ -1,0 +1,79 @@
+name: "AWS KMS Keys to CEF"
+description: "Maps AWS Key Management Service (KMS) key inventory records from the aws-kms connector into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-kms"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "kms"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS KMS key inventory -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2)
+          # owns all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (derived from KeyState)
+          #   - time fields (rt / deviceCustomDate1): epoch-MILLISECONDS
+          #   - custom slots cs*/cn*/flexString* ALWAYS paired with *Label
+          # One jq pass; shallow null-drop on the extension object only.
+          # ---------------------------------------------------------------
+
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else ( ( $ts
+                     | gsub("\\.[0-9]+"; "")
+                     | gsub("[+-][0-9]{2}:[0-9]{2}$"; "Z")
+                     | fromdateiso8601 ) * 1000 )
+            end;
+
+          def bit($b): if $b == true then 1 elif $b == false then 0 else null end;
+
+          . as $r
+          | ( $r.KeyMetadata // {} ) as $km
+          | ( $r.KeyRotationStatus // {} ) as $rot
+
+          | { _cef: {
+              vendor: "Amazon Web Services",
+              product: "AWS KMS",
+              version: "",
+              # Stable, low-cardinality event type — this connector reports
+              # key inventory, so the signature is constant per data source.
+              signature_id: "aws.kms.key.inventory",
+              name: ("AWS KMS key inventory: " + ($km.KeyId // "unknown")),
+              # KeyState drives operational severity: an enabled key is
+              # routine (2); disabled / pending-deletion keys warrant review.
+              severity: ( { "Enabled": 2,
+                            "Disabled": 5,
+                            "PendingImport": 5,
+                            "PendingReplicaDeletion": 6,
+                            "PendingDeletion": 6,
+                            "Unavailable": 7 }[$km.KeyState] // 3 ),
+              extension: ( {
+                rt:      to_epoch_ms($km.CreationDate),
+                act:     "Collect",
+                outcome: "SUCCESS",
+                cat:     "AWS KMS Key Inventory",
+                msg:     $km.Description,
+                deviceCustomDate1Label: "nextRotationDate",
+                deviceCustomDate1:      to_epoch_ms($rot.NextRotationDate),
+                cs1Label: "keyId",       cs1: $km.KeyId,
+                cs2Label: "keyArn",      cs2: $km.Arn,
+                cs3Label: "keyState",    cs3: $km.KeyState,
+                cs4Label: "keyUsage",    cs4: $km.KeyUsage,
+                cs5Label: "keySpec",     cs5: ($km.KeySpec // $km.CustomerMasterKeySpec),
+                cs6Label: "origin",      cs6: $km.Origin,
+                cn1Label: "rotationEnabled", cn1: bit($rot.KeyRotationEnabled),
+                cn2Label: "multiRegion",     cn2: bit($km.MultiRegion),
+                flexString1Label: "awsRegion",  flexString1: $r.Region,
+                flexString2Label: "keyManager", flexString2: $km.KeyManager
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-organizations.yaml
+++ b/cef/v0/aws/aws-organizations.yaml
@@ -1,0 +1,65 @@
+name: "AWS Organizations Account Inventory to CEF"
+description: "Maps AWS Organizations account inventory records (the ListAccounts / DescribeAccount Account object) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-organizations"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "organizations"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Organizations Account inventory -> CEF intermediate (T1).
+          # Do NOT escape anything here - the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (derived from account Status)
+          #   - rt: epoch-MILLISECONDS
+          #   - custom slots cs* ALWAYS paired with their *Label
+          #
+          # Input: ONE AWS Organizations Account record per invocation
+          #   .Id/.Arn/.Email/.Name/.Status/.JoinedMethod/.JoinedTimestamp
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          # arn:aws:organizations::<mgmt-acct-id>:account/<org-id>/<acct-id>
+          | ( ($r.Arn // "") | split("/") ) as $arn_parts
+          | ( if ($arn_parts | length) > 1 then $arn_parts[1] else null end ) as $org_id
+          | ( ($r.Arn // "") | split(":") ) as $arn_colon
+          | ( if ($arn_colon | length) > 4 and ($arn_colon[4] != "") then $arn_colon[4] else null end ) as $mgmt_id
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "AWS Organizations",
+              version: "",
+              signature_id: "organizations.account.inventory",
+              name: ("AWS Organizations account inventory: " + ($r.Name // $r.Id // "unknown")),
+              # Account lifecycle status -> 0-10 severity bucket. A healthy
+              # ACTIVE account is low; SUSPENDED / PENDING_CLOSURE warrant
+              # analyst attention.
+              severity: ( { "ACTIVE": 2, "PENDING_CLOSURE": 5, "SUSPENDED": 6 }[$r.Status] // 2 ),
+              extension: ( {
+                rt:        to_epoch_ms($r.JoinedTimestamp),
+                externalId: $r.Id,
+                suser:     $r.Email,
+                act:       "account-inventory",
+                outcome:   $r.Status,
+                cs1Label:  "accountArn",           cs1: $r.Arn,
+                cs2Label:  "accountName",           cs2: $r.Name,
+                cs3Label:  "organizationId",        cs3: $org_id,
+                cs4Label:  "joinedMethod",          cs4: $r.JoinedMethod,
+                cs5Label:  "managementAccountId",   cs5: $mgmt_id
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-rds-audit-logs.yaml
+++ b/cef/v0/aws/aws-rds-audit-logs.yaml
@@ -1,0 +1,72 @@
+name: "AWS RDS Audit Logs to CEF"
+description: "Maps AWS RDS (MySQL / MariaDB) audit log records — the MariaDB Audit Plugin CSV line in the connector's message field — into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-rds-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "rds"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS RDS Audit Logs -> CEF intermediate (T1). No escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. Emit final-form
+          # values: severity int 0-10, rt in epoch-MILLISECONDS, every cs*/cn*
+          # slot paired with its *Label.
+          #
+          # The connector envelope carries the raw MariaDB Audit Plugin CSV
+          # line in `message`:
+          #   ts,serverhost,username,host,connectionid,queryid,
+          #     operation,database,object,retcode
+          # `object` may contain commas and is single-quoted, so it is grabbed
+          # greedily up to the final comma (retcode is always last).
+          # ---------------------------------------------------------------
+
+          . as $r
+          | ( $r.message
+              | capture("^(?<ts>[^,]*),(?<serverhost>[^,]*),(?<username>[^,]*),(?<host>[^,]*),(?<connectionid>[^,]*),(?<queryid>[^,]*),(?<operation>[^,]*),(?<database>[^,]*),(?<object>.*),(?<retcode>[^,]*)$")
+            ) as $m
+          | ( ($m.object // "") | sub("^'"; "") | sub("'$"; "") | gsub("''"; "'") ) as $obj
+          | ( ($m.operation // "") | ascii_upcase ) as $op
+          | ( $m.retcode // "" ) as $ret
+          | ( try ($m.ts | strptime("%Y%m%d %H:%M:%S") | mktime * 1000) catch null ) as $rt
+          | ( if $ret == "0" or $ret == "" then "SUCCESS" else "FAILURE" end ) as $outcome
+          | ( if $ret != "0" and $ret != "" then 6
+              else ( { "DROP":7, "WRITE":5, "CREATE":5, "ALTER":5, "RENAME":5,
+                       "QUERY":3, "READ":3, "CONNECT":2, "DISCONNECT":2 }[$op] // 3 ) end ) as $severity
+
+          | { _cef: {
+              vendor: "Amazon",
+              product: "Amazon RDS",
+              version: "",
+              signature_id: $op,
+              name: ("RDS " + ($r.engine // "database") + " audit: " + $op),
+              severity: $severity,
+              extension: ( {
+                rt:      $rt,
+                suser:   $m.username,
+                src:     ( if ($m.host | test("^(\\d{1,3}\\.){3}\\d{1,3}$")) then $m.host else null end ),
+                shost:   $m.host,
+                dvchost: $m.serverhost,
+                act:     $op,
+                outcome: $outcome,
+                fname:   $r.log_file_name,
+                deviceExternalId: $r.instance_id,
+                cs1Label: "database",   cs1: (if ($m.database // "") == "" then null else $m.database end),
+                cs2Label: "query",      cs2: (if $obj == "" then null else $obj end),
+                cs3Label: "engine",     cs3: $r.engine,
+                cs4Label: "awsRegion",  cs4: $r.region,
+                cn1Label: "connectionId", cn1: (if ($m.connectionid | test("^-?[0-9]+$")) then ($m.connectionid | tonumber) else null end),
+                cn2Label: "queryId",      cn2: (if ($m.queryid | test("^-?[0-9]+$")) then ($m.queryid | tonumber) else null end),
+                cn3Label: "returnCode",   cn3: (if ($ret | test("^-?[0-9]+$")) then ($ret | tonumber) else null end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-redshift-audit-logs.yaml
+++ b/cef/v0/aws/aws-redshift-audit-logs.yaml
@@ -1,0 +1,68 @@
+name: "AWS Redshift Audit Logs to CEF"
+description: "Maps AWS Redshift database audit connection-log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-redshift-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "redshift"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Redshift connection log -> CEF intermediate (T1).
+          # NO escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Emit final-form values: severity int 0-10; times epoch-MS; every
+          # cs*/cn* custom slot paired with its *Label. One jq pass; shallow
+          # null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.event // "" | ascii_downcase) as $ev
+
+          # Failure auth events are higher severity than routine connects.
+          | ( if ($ev | test("fail|denied|error")) then 7
+              elif ($ev | test("disconnect")) then 2
+              else 3 end ) as $sev
+
+          | ( if ($ev | test("fail|denied|error")) then "FAILURE" else "SUCCESS" end ) as $outcome
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "Amazon Redshift",
+              version: "",
+              signature_id: ($r.event // "connection"),
+              name: ( "Redshift " + ($r.event // "connection event") ),
+              severity: $sev,
+              extension: ( {
+                rt:       to_epoch_ms($r.recordtime),
+                suser:    $r.username,
+                src:      $r.remotehost,
+                spt:      ( if $r.remoteport then ($r.remoteport | tonumber? // null) else null end ),
+                act:      $r.event,
+                outcome:  $outcome,
+                dproc:    $r.application_name,
+                # Custom slots (dictionary has no native home) — each paired
+                # with its label as the CEF spec requires.
+                cs1Label: "dbName",       cs1: $r.dbname,
+                cs2Label: "authMethod",   cs2: $r.authmethod,
+                cs3Label: "tlsVersion",   cs3: $r.sslversion,
+                cs4Label: "tlsCipher",    cs4: $r.sslcipher,
+                cs5Label: "clusterId",    cs5: $r.clusterid,
+                cs6Label: "sessionId",    cs6: $r.sessionid,
+                cn1Label: "pid",          cn1: $r.pid,
+                cn2Label: "durationMicros", cn2: $r.duration
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-resource-evaluations.yaml
+++ b/cef/v0/aws/aws-resource-evaluations.yaml
@@ -1,0 +1,67 @@
+name: "AWS Config Resource Evaluations to CEF"
+description: "Maps AWS Config resource compliance evaluation results (EvaluationResult) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-resource-evaluations"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "config"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Config resource evaluations -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Emit FINAL-FORM values: severity int 0-10, times epoch-MS,
+          # custom cs*/flexString* slots each paired with a *Label.
+          # One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ( $r.EvaluationResultIdentifier // {} ) as $id
+          | ( $id.EvaluationResultQualifier // {} ) as $q
+          | ( $r.ComplianceType // "" ) as $ct
+
+          # Source compliance -> CEF severity bucket (0-10):
+          #   NON_COMPLIANT is a High-severity finding; a passing / N/A
+          #   result is low; missing data is medium-low.
+          | ( { "NON_COMPLIANT": 7, "COMPLIANT": 2,
+                "NOT_APPLICABLE": 2, "INSUFFICIENT_DATA": 3 }[$ct] // 0 ) as $sev
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "AWS Config",
+              version: "",
+              signature_id: ($q.ConfigRuleName // "aws-config-rule"),
+              name: ( ($q.ConfigRuleName // "AWS Config rule")
+                      + ": " + (if $ct != "" then $ct else "UNKNOWN" end) ),
+              severity: $sev,
+              extension: ( {
+                rt:       to_epoch_ms($r.ResultRecordedTime // $id.OrderingTimestamp),
+                act:      "resource-evaluation",
+                outcome:  (if $ct != "" then $ct else null end),
+                msg:      $r.Annotation,
+                externalId: $id.ResourceEvaluationId,
+                deviceCustomDate1Label: "ConfigRuleInvokedTime",
+                deviceCustomDate1: to_epoch_ms($r.ConfigRuleInvokedTime),
+                cs1Label: "ConfigRuleName", cs1: $q.ConfigRuleName,
+                cs2Label: "ResourceType",   cs2: $q.ResourceType,
+                cs3Label: "ResourceId",     cs3: $q.ResourceId,
+                cs4Label: "ComplianceType", cs4: (if $ct != "" then $ct else null end),
+                cs5Label: "EvaluationMode", cs5: $q.EvaluationMode,
+                cs6Label: "AwsRegion",      cs6: $r.AwsRegion,
+                flexString1Label: "AwsAccountId", flexString1: $r.AwsAccountId
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-secrets-manager.yaml
+++ b/cef/v0/aws/aws-secrets-manager.yaml
@@ -1,0 +1,82 @@
+name: "AWS Secrets Manager Secret Inventory to CEF"
+description: "Maps AWS Secrets Manager secret inventory records (ListSecrets/DescribeSecret metadata) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-secrets-manager"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "secrets-manager"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Secrets Manager secret inventory -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (rotation-disabled secrets are riskier)
+          #   - all time fields: epoch-MILLISECONDS
+          #   - custom slots cs*/cn*/deviceCustomDate* ALWAYS paired w/ *Label
+          # One jq pass, per-record only; shallow with_entries null-drop.
+          # ---------------------------------------------------------------
+
+          # Secrets Manager timestamps are epoch SECONDS (sometimes fractional).
+          # CEF wants epoch-MILLISECONDS.
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number"
+              then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else null end;
+
+          def obj($o): if ($o | type) == "object" then $o else null end;
+
+          . as $r
+          | ( obj($r.RotationRules) ) as $rr
+          | ( $r.RotationEnabled == true ) as $rot_on
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "AWS Secrets Manager",
+              version: "",
+              signature_id: "aws.secretsmanager.inventory",
+              name: ( "Secrets Manager secret inventory: " + ($r.Name // ($r.ARN // "unknown")) ),
+              # Rotation-disabled secrets carry more standing risk than
+              # actively-rotated ones — bucket accordingly (per-record only).
+              severity: ( if $rot_on then 2 else 5 end ),
+              extension: ( {
+                rt:         to_epoch_ms($r.LastChangedDate),
+                start:      to_epoch_ms($r.CreatedDate),
+                end:        to_epoch_ms($r.NextRotationDate),
+                externalId: $r.ARN,
+                act:        "inventory",
+                cat:        "secret-inventory",
+                outcome:    "SUCCESS",
+                msg:        $r.Description,
+                # deviceCustomDate slots (epoch-ms) with their labels.
+                deviceCustomDate1:      to_epoch_ms($r.LastRotatedDate),
+                deviceCustomDate1Label: "lastRotatedDate",
+                deviceCustomDate2:      to_epoch_ms($r.LastAccessedDate),
+                deviceCustomDate2Label: "lastAccessedDate",
+                # cn / cs custom slots, each with its label.
+                cn1:      ( if $rr != null then $rr.AutomaticallyAfterDays else null end ),
+                cn1Label: "rotationAfterDays",
+                cs1:      $r.OwningService,
+                cs1Label: "owningService",
+                cs2:      $r.KmsKeyId,
+                cs2Label: "kmsKeyId",
+                cs3:      $r.RotationLambdaARN,
+                cs3Label: "rotationLambdaArn",
+                cs4:      $r.PrimaryRegion,
+                cs4Label: "primaryRegion",
+                cs5:      ( if $r.RotationEnabled == null then null else ($r.RotationEnabled | tostring) end ),
+                cs5Label: "rotationEnabled",
+                cs6:      ( ($r.SecretVersionsToStages // {}) | [ .[] ] | add // [] | unique | join(",") ),
+                cs6Label: "versionStages"
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-security-groups.yaml
+++ b/cef/v0/aws/aws-security-groups.yaml
@@ -1,0 +1,68 @@
+name: "AWS Security Groups to CEF"
+description: "Maps AWS EC2 Security Group inventory records (from the aws-security-groups input connector) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-security-groups"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "security-groups"
+  - "cloud-security"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS Security Groups -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values (severity int 0-10; times
+          # epoch-MILLISECONDS; every cs*/cn* slot paired with its *Label).
+          #
+          # Input: one EC2 SecurityGroup record (SDK/JSON PascalCase):
+          #   { GroupId, GroupName, Description, VpcId, OwnerId,
+          #     SecurityGroupArn, IpPermissions[], IpPermissionsEgress[],
+          #     Tags[] }.
+          # A security group carries no event time of its own, so rt is
+          # stamped at collection (now, epoch-ms). Severity is Low for a
+          # normal group, raised when an ingress rule is open to 0.0.0.0/0
+          # or ::/0. One jq pass; shallow null-drop; no escaping.
+          # ---------------------------------------------------------------
+          . as $r
+          | ( ($r.SecurityGroupArn // "") | split(":") ) as $arn
+          | ( if ($arn | length) > 3 and ($arn[3] != "") then $arn[3] else null end ) as $region
+          | ( ($r.IpPermissions // [])
+              | map( ( (.IpRanges   // []) | map(.CidrIp   == "0.0.0.0/0") | any )
+                     or ( (.Ipv6Ranges // []) | map(.CidrIpv6 == "::/0")     | any ) )
+              | map(select(.)) | length ) as $world_open_ingress
+          | ( ($r.Tags // []) | map("\(.Key)=\(.Value)") | join(",") ) as $tag_str
+          | { _cef: {
+              vendor: "AWS",
+              product: "Amazon EC2 Security Groups",
+              version: "",
+              signature_id: "aws.ec2.security-group.inventory",
+              name: ( "Security group \($r.GroupName // $r.GroupId) (\($r.GroupId)) inventory" ),
+              # Informational inventory = Low (2); a group exposed to the whole
+              # internet is raised to Medium (6).
+              severity: ( if $world_open_ingress > 0 then 6 else 2 end ),
+              extension: ( {
+                rt:       (now * 1000 | floor),
+                act:      "security-group-inventory",
+                outcome:  "SUCCESS",
+                cat:      "Cloud Security Group Inventory",
+                msg:      $r.Description,
+                dvchost:  $r.SecurityGroupArn,
+                cs1Label: "securityGroupId",   cs1: $r.GroupId,
+                cs2Label: "vpcId",             cs2: $r.VpcId,
+                cs3Label: "ownerAccountId",    cs3: $r.OwnerId,
+                cs4Label: "region",            cs4: $region,
+                cs5Label: "tags",              cs5: ( if $tag_str == "" then null else $tag_str end ),
+                cn1Label: "ingressRuleCount",  cn1: (($r.IpPermissions // []) | length),
+                cn2Label: "egressRuleCount",   cn2: (($r.IpPermissionsEgress // []) | length),
+                cn3Label: "worldOpenIngressRuleCount", cn3: $world_open_ingress
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/aws/aws-sqs-s3-cloudtrail.yaml
+++ b/cef/v0/aws/aws-sqs-s3-cloudtrail.yaml
@@ -1,0 +1,84 @@
+name: "AWS CloudTrail (SQS/S3) to CEF"
+description: "Maps AWS CloudTrail event records from the aws-sqs-s3-cloudtrail connector into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "aws-sqs-s3-cloudtrail"
+tags:
+  - "v0"
+  - "cef"
+  - "aws"
+  - "cloudtrail"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # AWS CloudTrail -> CEF intermediate (T1).
+          # Input: ONE raw CloudTrail event record per invocation
+          # (aws-sqs-s3-cloudtrail connector, per_record chunking).
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping. Values are FINAL FORM: severity int 0-10, times
+          # epoch-MILLISECONDS, custom cs* slots paired with *Label.
+          # One jq pass; shallow null-drop on the extension object only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+
+          def real_name($s):
+            if ($s | type) == "string" and $s != "HIDDEN_DUE_TO_SECURITY_REASONS"
+            then $s else null end;
+
+          def session_name($p):
+            if ($p | type) == "string" and ($p | test(":"))
+            then ($p | sub("^[^:]*:"; "")) else null end;
+
+          . as $r
+          | ( $r.userIdentity // {} ) as $ui
+          | ( $ui.sessionContext // {} ) as $sc
+          | ( $sc.sessionIssuer // {} ) as $si
+          | ( ($r.errorCode // null) != null ) as $failed
+          | ( session_name($ui.principalId)
+              // real_name($ui.userName)
+              // real_name($si.userName) ) as $actor
+
+          | { _cef: {
+              vendor: "AWS",
+              product: "AWS CloudTrail",
+              version: ($r.eventVersion // ""),
+              # The API action is the stable, low-cardinality event signature.
+              signature_id: $r.eventName,
+              name: (($r.eventName // "API call") + " on " + ($r.eventSource // "aws")),
+              # A rejected call is more notable than a routine read; write
+              # activity sits in between.
+              severity: ( if $failed then 7
+                          elif ($r.readOnly // false) == true then 2
+                          else 4 end ),
+              extension: ( {
+                rt:      to_epoch_ms($r.eventTime),
+                act:     $r.eventName,
+                suser:   $actor,
+                suid:    $ui.principalId,
+                src:     ( if is_ip($r.sourceIPAddress) then $r.sourceIPAddress else null end ),
+                outcome: ( if $failed then "FAILURE" else "SUCCESS" end ),
+                requestClientApplication: $r.userAgent,
+                # Custom slots (paired with their labels) for AWS-specific
+                # context that has no CEF dictionary home.
+                cs1Label: "awsRegion",       cs1: $r.awsRegion,
+                cs2Label: "eventSource",     cs2: $r.eventSource,
+                cs3Label: "accountId",       cs3: ($r.recipientAccountId // $ui.accountId),
+                cs4Label: "principalArn",    cs4: $ui.arn,
+                cs5Label: "requestId",       cs5: $r.requestID,
+                cs6Label: "sourceIPAddress", cs6: $r.sourceIPAddress
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/bitwarden/bitwarden-events.yaml
+++ b/cef/v0/bitwarden/bitwarden-events.yaml
@@ -1,0 +1,85 @@
+name: "Bitwarden Event Logs to CEF"
+description: "Maps Bitwarden Events (organization audit log) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "bitwarden-events"
+tags:
+  - "v0"
+  - "cef"
+  - "bitwarden"
+  - "events"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Bitwarden Events -> CEF intermediate (T1). No escaping here — the
+          # shared CEF Serializer (T2) owns all escaping. Final-form values:
+          #   severity integer 0-10; rt epoch-MILLISECONDS; cs*/cn* + *Label.
+          # Input: one Bitwarden Public API /public/events record.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          def device_name($d):
+            {
+              "0":"Android","1":"iOS","2":"Chrome Extension","3":"Firefox Extension",
+              "4":"Opera Extension","5":"Edge Extension","6":"Windows Desktop",
+              "7":"macOS Desktop","8":"Linux Desktop","9":"Chrome Browser",
+              "10":"Firefox Browser","11":"Opera Browser","12":"Edge Browser",
+              "13":"IE Browser","14":"Unknown Browser","15":"Android (Amazon)",
+              "16":"UWP","17":"Safari Browser","18":"Vivaldi Browser",
+              "19":"Vivaldi Extension","20":"Safari Extension","21":"SDK"
+            }[$d | tostring];
+
+          def event_name($t):
+            {
+              "1000":"Logged in","1001":"Changed account password",
+              "1002":"Enabled/updated two-step login","1003":"Disabled two-step login",
+              "1004":"Recovered account from two-step login","1005":"Login attempt failed (bad password)",
+              "1006":"Login attempt failed (bad two-step)","1007":"Exported individual vault",
+              "1008":"Account recovery requested","1009":"Account recovery key migrated"
+            }[$t | tostring] // "Bitwarden event";
+
+          . as $r
+          | ($r.type) as $t
+          | (($t == 1005) or ($t == 1006)) as $failed
+          | ($r.actingUserId // $r.memberId) as $uid
+          | { _cef: {
+                vendor: "Bitwarden",
+                product: "Bitwarden Event Logs",
+                version: "",
+                signature_id: ($t | tostring),
+                name: event_name($t),
+                severity: ( if $failed then 7
+                            elif ($t == 1002 or $t == 1003 or $t == 1007) then 5
+                            else 2 end ),
+                # Each custom slot is added as a Label+value PAIR only when its
+                # source field is present, so a *Label never appears orphaned.
+                extension: ( (
+                  {
+                    rt:      to_epoch_ms($r.date),
+                    suser:   $uid,
+                    src:     $r.ipAddress,
+                    act:     event_name($t),
+                    outcome: ( if $t == 1000 then "SUCCESS"
+                               elif $failed then "FAILURE" else "UNKNOWN" end),
+                    cs1Label: "bitwardenEventType", cs1: ($t | tostring)
+                  }
+                  + ( if $r.device != null
+                      then { cs2Label: "deviceType", cs2: device_name($r.device),
+                             cn1Label: "deviceCode", cn1: $r.device }
+                      else {} end )
+                  + ( if $r.memberId != null
+                      then { cs3Label: "memberId", cs3: $r.memberId } else {} end )
+                  + ( if $r.itemId != null
+                      then { cs4Label: "itemId", cs4: $r.itemId } else {} end )
+                ) | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/bitwarden/bitwarden-users.yaml
+++ b/cef/v0/bitwarden/bitwarden-users.yaml
@@ -1,0 +1,51 @@
+name: "Bitwarden Organization Members to CEF"
+description: "Maps Bitwarden Public API organization member records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "bitwarden-users"
+tags:
+  - "v0"
+  - "cef"
+  - "bitwarden"
+  - "users"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Bitwarden organization member -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Final-form values: severity int 0-10; times epoch-MS; every
+          # cs*/cn* slot paired with its *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          . as $m
+          | ( { "0": "Owner", "1": "Admin", "2": "User", "3": "Manager" }[($m.type // -1 | tostring)] // "Unknown" ) as $role
+          | ( { "-1": "Revoked", "0": "Invited", "1": "Accepted", "2": "Confirmed" }[($m.status // -99 | tostring)] // "Unknown" ) as $status
+          # privileged roles rank higher on the 0-10 severity scale
+          | ( { "0": 6, "1": 5, "2": 3, "3": 4 }[($m.type // -1 | tostring)] // 2 ) as $sev
+          | { _cef: {
+              vendor:  "Bitwarden",
+              product: "Bitwarden Password Manager",
+              version: "",
+              signature_id: "org.member.inventory",
+              name: ("Organization member inventory: " + ($m.email // $m.id // "unknown")),
+              severity: $sev,
+              extension: ( {
+                rt:      (now * 1000 | floor),
+                suser:   $m.email,
+                suid:    $m.userId,
+                act:     "member-inventory",
+                outcome: $status,
+                cs1Label: "role",              cs1: $role,
+                cs2Label: "membershipStatus",  cs2: $status,
+                cs3Label: "externalId",        cs3: $m.externalId,
+                cs4Label: "collections",       cs4: (if $m.collections then ($m.collections | tostring) else null end),
+                cs5Label: "memberId",          cs5: $m.id,
+                cn1Label: "twoFactorEnabled",  cn1: (if $m.twoFactorEnabled == true then 1 elif $m.twoFactorEnabled == false then 0 else null end),
+                cn2Label: "accessAll",         cn2: (if $m.accessAll == true then 1 elif $m.accessAll == false then 0 else null end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/box/box-users.yaml
+++ b/cef/v0/box/box-users.yaml
@@ -1,0 +1,69 @@
+name: "Box Users to CEF"
+description: "Maps Box User account records (Admin API /2.0/users) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "box-users"
+tags:
+  - "v0"
+  - "cef"
+  - "box"
+  - "users"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Box User account -> CEF intermediate (T1). No escaping here — the
+          # shared CEF Serializer (T2) owns all escaping. Values FINAL-FORM:
+          #   severity integer 0-10; times epoch-MILLISECONDS; cs*/cn* paired
+          #   with *Label. One jq pass; shallow null-drop on extension.
+          # ---------------------------------------------------------------
+          # RFC3339 with numeric offset (Box) -> epoch MILLISECONDS (UTC)
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else
+              ($ts | capture("^(?<d>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2})(?:\\.[0-9]+)?(?<tz>Z|[+-][0-9]{2}:[0-9]{2})$")) as $m
+              | (($m.d + "Z") | fromdateiso8601) as $base
+              | (if $m.tz == "Z" then 0
+                 else (($m.tz[1:3] | tonumber) * 3600 + ($m.tz[4:6] | tonumber) * 60) as $secs
+                      | (if ($m.tz[0:1]) == "-" then $secs else (- $secs) end)
+                 end) as $adj
+              | (($base + $adj) * 1000)
+            end;
+
+          . as $u |
+          (if ($u.role // "user") == "admin" or ($u.role // "") == "coadmin" then 5 else 2 end) as $sev |
+          {
+            _cef: {
+              vendor: "Box",
+              product: "Box",
+              version: "",
+              signature_id: "user.inventory",
+              name: ("Box user account: " + ($u.login // ($u.id | tostring))),
+              severity: $sev,
+              extension: ( {
+                rt:      to_epoch_ms($u.modified_at // $u.created_at),
+                deviceCustomDate1:      to_epoch_ms($u.created_at),
+                deviceCustomDate1Label: "accountCreated",
+                suid:    ($u.id | tostring),
+                suser:   ($u.login // $u.name),
+                shost:   $u.hostname,
+                outcome: ($u.status // null),
+                act:     "user-inventory",
+                msg:     ("Box user " + ($u.login // ($u.id | tostring)) + " status=" + ($u.status // "unknown") + " role=" + ($u.role // "user")),
+                cs1Label: "role",       cs1: $u.role,
+                cs2Label: "status",     cs2: $u.status,
+                cs3Label: "enterprise", cs3: ($u.enterprise.name // null),
+                cs4Label: "jobTitle",   cs4: $u.job_title,
+                cs5Label: "enterpriseId", cs5: ($u.enterprise.id // null),
+                cs6Label: "timezone",   cs6: $u.timezone,
+                cn1Label: "spaceUsed",  cn1: $u.space_used,
+                cn2Label: "spaceAmount", cn2: $u.space_amount
+              } | with_entries(select(.value != null and .value != "")) )
+            }
+          }

--- a/cef/v0/brinqa/brinqa-audit-logs.yaml
+++ b/cef/v0/brinqa/brinqa-audit-logs.yaml
@@ -1,0 +1,61 @@
+name: "Brinqa Audit Logs to CEF"
+description: "Maps Brinqa audit and security event log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "brinqa-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "brinqa"
+  - "audit-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Brinqa audit logs -> CEF intermediate (T1). No escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. Final-form
+          # values: severity int 0-10, times epoch-MS, custom slots paired
+          # with *Label.
+          # Documented fields: category, user, createdBy, dateCreated,
+          # lastUpdated, timestamp, msg, detail, outcome, severity, stacktrace.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number"
+              then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          def lc($s): ($s // "" | ascii_downcase);
+
+          . as $r
+          | lc($r.severity) as $sev
+          | lc($r.outcome) as $oc
+          | { _cef: {
+              vendor:  "Brinqa",
+              product: "Brinqa",
+              version: "",
+              signature_id: ($r.category // "Audit"),
+              name:    ($r.msg // $r.detail // "Brinqa audit event"),
+              severity: (if   $sev == "info" or $sev == "informational" then 2
+                         elif $sev == "low"                             then 3
+                         elif $sev == "warn" or $sev == "warning" or $sev == "medium" then 5
+                         elif $sev == "error" or $sev == "high"         then 7
+                         elif $sev == "critical"                        then 9
+                         elif $sev == "fatal"                           then 10
+                         else 0 end),
+              extension: ( {
+                rt:      to_epoch_ms($r.timestamp // $r.dateCreated),
+                suser:   ($r.user // $r.createdBy),
+                cat:     $r.category,
+                msg:     ($r.detail // $r.msg),
+                outcome: (($r.outcome // "") | if . == "" then null else ascii_upcase end),
+                cs1Label: "brinqaSeverity", cs1: $r.severity,
+                cs2Label: "createdBy",      cs2: $r.createdBy,
+                cs3Label: "eventCategory",  cs3: $r.category
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/bugsnag/bugsnag-org-events.yaml
+++ b/cef/v0/bugsnag/bugsnag-org-events.yaml
@@ -1,0 +1,64 @@
+name: "BugSnag Org Events to CEF"
+description: "Maps BugSnag organization error/crash events into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "bugsnag-org-events"
+tags:
+  - "v0"
+  - "cef"
+  - "bugsnag"
+  - "org-events"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # BugSnag org error event -> CEF intermediate (T1). No escaping.
+          # severity: integer 0-10; times epoch-ms; cs*/cn* paired with labels.
+          # ---------------------------------------------------------------
+          . as $r
+          | ($r.exceptions[0] // {}) as $ex
+          | ($r.app // {}) as $app
+          | ($r.device // {}) as $dev
+          | ($r.user // {}) as $usr
+          | ($r.request // {}) as $req
+
+          | def to_epoch_ms($ts):
+              if $ts == null then null
+              elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+              else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+              end;
+
+          { _cef: {
+              vendor: "BugSnag",
+              product: "BugSnag",
+              version: ($app.version // ""),
+              signature_id: ($ex.error_class // "UnknownError"),
+              name: ($ex.message // $r.context // "Application error"),
+              severity: ( { "error": 8, "warning": 5, "info": 3 }[$r.severity] // 0 ),
+              extension: ( {
+                rt:            to_epoch_ms($r.received_at),
+                msg:           ($ex.message // $r.context),
+                outcome:       "FAILURE",
+                suid:          $usr.id,
+                suser:         ($usr.email // $usr.name),
+                src:           $req.client_ip,
+                request:       $req.url,
+                requestMethod: $req.http_method,
+                dhost:         $dev.hostname,
+                deviceExternalId: $dev.id,
+                app:           $app.id,
+                # Custom slots (each paired with its *Label).
+                cs1Label: "errorClass",   cs1: $ex.error_class,
+                cs2Label: "releaseStage",  cs2: $app.release_stage,
+                cs3Label: "context",       cs3: $r.context,
+                cs4Label: "os",            cs4: (if $dev.os_name != null then ($dev.os_name + " " + ($dev.os_version // "")) else null end),
+                cs5Label: "unhandled",     cs5: (if $r.unhandled == null then null else ($r.unhandled | tostring) end),
+                cs6Label: "errorId",       cs6: $r.error_id,
+                cn1Label: "durationMs",    cn1: $app.duration
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/buildkite/buildkite-audit-logs.yaml
+++ b/cef/v0/buildkite/buildkite-audit-logs.yaml
@@ -1,0 +1,62 @@
+name: "Buildkite Audit Logs to CEF"
+description: "Maps Buildkite Audit Log events into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "buildkite-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "buildkite"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Buildkite Audit Logs -> CEF intermediate (T1). NO escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. Final-form values:
+          #   severity integer 0-10; times epoch-MILLISECONDS; cs*/cn* + *Label.
+          # One jq pass; shallow null-drop on extension (no recursive walk).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.type // "") as $t
+          # Deletions/removals weigh heavier than creations/reads.
+          | (if   ($t | test("_DELETED$|_REVOKED$|_REMOVED$")) then 6
+             elif ($t | test("_CREATED$|_UPDATED$|_ADDED$"))   then 3
+             else 2 end) as $sev
+          | { _cef: {
+              vendor: "Buildkite",
+              product: "Buildkite Audit Log",
+              version: "",
+              signature_id: $t,
+              name: ($t | gsub("_"; " ") | ascii_downcase),
+              severity: $sev,
+              extension: ( {
+                rt:      to_epoch_ms($r.occurred_at),
+                externalId: $r.uuid,
+                # Acting administrator (actor)
+                suser:   ($r.actor.name // null),
+                suid:    ($r.actor.uuid // null),
+                # Target of the action (subject)
+                duser:   ($r.subject.name // null),
+                duid:    ($r.subject.uuid // null),
+                src:     ($r.context.request_ip // null),
+                requestClientApplication: ($r.context.request_user_agent // null),
+                act:     $t,
+                outcome: "SUCCESS",
+                cs1Label: "subjectType",  cs1: ($r.subject.type // null),
+                cs2Label: "actorType",    cs2: ($r.actor.type // null),
+                cs3Label: "eventUrl",     cs3: ($r.url // null),
+                cs4Label: "targetEmail",  cs4: ($r.data.email // null)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/captivateiq/captivate-iq-audit-logs.yaml
+++ b/cef/v0/captivateiq/captivate-iq-audit-logs.yaml
@@ -1,0 +1,57 @@
+name: "CaptivateIQ Audit Logs to CEF"
+description: "Maps CaptivateIQ Audit Logs records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "captivate-iq-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "captivateiq"
+  - "audit-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # CaptivateIQ audit_log -> CEF intermediate (T1). No escaping here;
+          # the shared serializer (T2) owns escaping/header assembly. Emit
+          # final-form values: severity int 0-10, times epoch-ms, every cs*
+          # slot paired with its label. One jq pass; shallow null-drop only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.event_type // "" | ascii_downcase) as $et
+          | ( { "create": 4, "update": 4, "delete": 6 }[$et] // 3 ) as $sev
+          | { _cef: {
+              vendor: "CaptivateIQ",
+              product: "CaptivateIQ Audit Log",
+              version: (if $r.version != null then ($r.version | tostring) else "" end),
+              signature_id: ($r.event_type // "event"),
+              name: ( ($r.event_type // "event") + " " + ($r.object_type // "object")
+                      + ( if $r.object_name != null then ": " + $r.object_name else "" end ) ),
+              severity: $sev,
+              extension: ( {
+                rt:          to_epoch_ms($r.created_at),
+                suser:       ($r.user_email // $r.user_name),
+                suid:        $r.user_id,
+                src:         $r.ip_address,
+                act:         $r.event_type,
+                outcome:     "SUCCESS",
+                externalId:  $r.id,
+                cs1Label: "objectType",           cs1: $r.object_type,
+                cs2Label: "objectName",           cs2: $r.object_name,
+                cs3Label: "objectId",             cs3: $r.object_id,
+                cs4Label: "organizationName",     cs4: $r.organization_name,
+                cs5Label: "loggedInUserEmail",    cs5: ( if ($r.logged_in_user_id != null and $r.logged_in_user_id != $r.user_id) then $r.logged_in_user_email else null end ),
+                cs6Label: "organizationId",       cs6: $r.organization_id
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cisa/cisa-kev.yaml
+++ b/cef/v0/cisa/cisa-kev.yaml
@@ -1,0 +1,61 @@
+name: "CISA Known Exploited Vulnerabilities to CEF"
+description: "Maps CISA Known Exploited Vulnerabilities (KEV) catalog entries into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cisa-kev"
+tags:
+  - "v0"
+  - "cef"
+  - "cisa"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # CISA KEV catalog entry -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns it.
+          # Emit final-form values: severity 0-10, times epoch-MILLISECONDS,
+          # every cs* slot paired with its *Label. One jq pass; shallow
+          # null-drop on `extension` only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else
+              ( ( $ts
+                  | if test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$") then . + "T00:00:00Z" else . end
+                  | gsub("\\.[0-9]+Z?$"; "Z")
+                  | fromdateiso8601 ) * 1000 )
+            end;
+
+          . as $r |
+          (($r.cwes // []) | join(",")) as $cwe_str |
+          # All KEV entries are actively exploited (high); ransomware-linked
+          # entries escalate to the top of the band.
+          (if (($r.knownRansomwareCampaignUse // "") | ascii_downcase) == "known"
+             then 9 else 7 end) as $sev |
+
+          { _cef: {
+              vendor: "CISA",
+              product: "Known Exploited Vulnerabilities Catalog",
+              version: "",
+              signature_id: ($r.cveID),
+              name: ($r.vulnerabilityName),
+              severity: $sev,
+              extension: ( {
+                rt:   to_epoch_ms($r.dateAdded),
+                end:  to_epoch_ms($r.dueDate),
+                msg:  $r.shortDescription,
+                reason: $r.requiredAction,
+                cs1Label: "vendorProject",              cs1: $r.vendorProject,
+                cs2Label: "product",                    cs2: $r.product,
+                cs3Label: "cwes",                       cs3: (if $cwe_str == "" then null else $cwe_str end),
+                cs4Label: "knownRansomwareCampaignUse", cs4: $r.knownRansomwareCampaignUse,
+                cs5Label: "cveID",                      cs5: $r.cveID
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cisco-meraki/cisco-meraki-config-logs.yaml
+++ b/cef/v0/cisco-meraki/cisco-meraki-config-logs.yaml
@@ -1,0 +1,54 @@
+name: "Cisco Meraki Configuration Changes to CEF"
+description: "Maps Cisco Meraki Dashboard configuration change (audit) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cisco-meraki-config-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "cisco-meraki"
+  - "config-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cisco Meraki Dashboard configurationChanges -> CEF intermediate (T1).
+          # No escaping here (the shared serializer owns it). Times epoch-ms;
+          # custom cs*/cn* slots always paired with their *Label. One jq pass;
+          # shallow null-drop on the extension object only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | { _cef: {
+              vendor: "Cisco",
+              product: "Meraki Dashboard",
+              version: "",
+              signature_id: "configuration_change",
+              name: ($r.label // $r.page // "Configuration change"),
+              severity: 2,
+              extension: ( {
+                rt:      to_epoch_ms($r.ts),
+                suser:   $r.adminName,
+                suid:    $r.adminId,
+                act:     $r.page,
+                outcome: "SUCCESS",
+                deviceExternalId: $r.networkId,
+                cs1Label: "label",       cs1: $r.label,
+                cs2Label: "oldValue",    cs2: $r.oldValue,
+                cs3Label: "newValue",    cs3: $r.newValue,
+                cs4Label: "networkName", cs4: $r.networkName,
+                cs5Label: "ssidName",    cs5: $r.ssidName,
+                cs6Label: "adminEmail",  cs6: $r.adminEmail,
+                cn1Label: "ssidNumber",  cn1: $r.ssidNumber
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-access-login-events.yaml
+++ b/cef/v0/cloudflare/cloudflare-access-login-events.yaml
@@ -1,0 +1,56 @@
+name: "Cloudflare Access Login Events to CEF"
+description: "Maps Cloudflare Access authentication (login) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-access-login-events"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "access-login-events"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare Access authentication log -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns it.
+          # severity: integer 0-10; rt: epoch-ms; custom slots paired w/ label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          def truthy($v):
+            ($v == true) or (($v | type) == "string" and ($v | ascii_downcase) == "true");
+
+          . as $r
+          | (truthy($r.allowed)) as $ok
+          | ($r.action // "access") as $act
+          | ($r.app_domain // "" | split("/")[0]) as $app_host
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "Cloudflare Access",
+              version: "",
+              signature_id: $act,
+              name: ("Access " + $act + (if $ok then " allowed" else " denied" end)),
+              severity: (if $ok then 2 else 7 end),
+              extension: ( {
+                rt:         to_epoch_ms($r.created_at),
+                suser:      $r.user_email,
+                src:        $r.ip_address,
+                act:        $r.action,
+                outcome:    (if $ok then "SUCCESS" else "FAILURE" end),
+                dhost:      (if $app_host == "" then null else $app_host end),
+                request:    (if ($r.app_domain // "") == "" then null else ("https://" + $r.app_domain) end),
+                externalId: $r.ray_id,
+                cs1Label: (if ($r.connection // "") == "" then null else "idpConnection" end), cs1: $r.connection,
+                cs2Label: (if ($r.app_uid // "") == "" then null else "appUid" end),        cs2: $r.app_uid,
+                cs3Label: (if ($r.country // "") == "" then null else "srcCountry" end),    cs3: $r.country
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-audit-logs.yaml
+++ b/cef/v0/cloudflare/cloudflare-audit-logs.yaml
@@ -1,0 +1,76 @@
+name: "Cloudflare Audit Logs to CEF"
+description: "Maps Cloudflare account Audit Log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare Audit Logs -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2)
+          # owns all escaping. Emit FINAL-FORM values (severity 0-10, times
+          # epoch-MILLISECONDS, cs*/cn* slots paired with their *Label).
+          #
+          # Input: ONE Cloudflare (classic) audit-log record per invocation:
+          #   { id, action{type,result}, actor{id,email,ip,type}, interface,
+          #     metadata{...}, newValue, oldValue, owner{id},
+          #     resource{id,type}, when }
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          def sval($v): if $v == null then null else ($v | tostring) end;
+
+          # Emit a csN slot together with its label ONLY when it has a value,
+          # so no orphan cs*Label is left behind (shallow, single-level).
+          def cs($n; $label; $v):
+            if ($v == null or $v == "") then {}
+            else { ("cs" + ($n|tostring) + "Label"): $label, ("cs" + ($n|tostring)): $v } end;
+
+          . as $r
+          | ($r.action // {}) as $act
+          | ($r.actor // {}) as $ac
+          | ($r.resource // {}) as $res
+          | ($r.metadata // {}) as $md
+          | ($act.type // "") as $atype
+          | ( ($act.result == true) or (($act.result | type) == "string" and ($act.result | ascii_downcase) == "true") ) as $ok
+
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "Cloudflare Audit Logs",
+              version: "",
+              signature_id: (if $atype == "" then "audit" else $atype end),
+              name: ("Cloudflare " + $atype + (if ($res.type // "") != "" then (" on " + $res.type) else "" end)),
+              # success = informational (3); failure = elevated (6).
+              severity: (if $ok then 3 else 6 end),
+              extension: ( (
+                {
+                  rt:      to_epoch_ms($r.when),
+                  suser:   $ac.email,
+                  suid:    $ac.id,
+                  src:     $ac.ip,
+                  act:     $atype,
+                  outcome: (if $ok then "SUCCESS" else "FAILURE" end)
+                }
+                + cs(1; "resourceType"; $res.type)
+                + cs(2; "resourceId";   $res.id)
+                + cs(3; "interface";    $r.interface)
+                + cs(4; "settingName";  ($md.name // $md.zone_name))
+                + cs(5; "newValue";     (sval($r.newValue)))
+                + cs(6; "oldValue";     (sval($r.oldValue)))
+              ) | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-ddos-attack-analytics.yaml
+++ b/cef/v0/cloudflare/cloudflare-ddos-attack-analytics.yaml
@@ -1,0 +1,68 @@
+name: "Cloudflare DDoS Attack Analytics to CEF"
+description: "Maps Cloudflare DDoS Attack Analytics (dosdAttackAnalyticsGroups GraphQL) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-ddos-attack-analytics"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "ddos-attack-analytics"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare DDoS Attack Analytics -> CEF intermediate (T1).
+          # One dosdAttackAnalyticsGroups row (dimensions{} + sum{}) per
+          # invocation. NO escaping here — the shared serializer (T2) owns
+          # all escaping. Times epoch-MS; custom slots paired with *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.dimensions // {}) as $d
+          | ($r.sum // {}) as $s
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "DDoS Protection",
+              version: "",
+              # Low-cardinality, stable event type for the signature.
+              signature_id: ($d.attackVector // $d.attackType // "ddos.attack"),
+              name: ( [ ($d.attackType // "DDoS attack"), " mitigated" ] | add ),
+              # DDoS attacks are high severity; a mitigated attack is a
+              # confirmed, actioned attack event.
+              severity: 8,
+              extension: ( {
+                rt:    to_epoch_ms($d.datetime),
+                start: to_epoch_ms($d.startDatetime),
+                end:   to_epoch_ms($d.endDatetime),
+                dst:   $d.destinationIP,
+                dpt:   $d.destinationPort,
+                spt:   $d.sourcePort,
+                proto: $d.attackProtocol,
+                act:   $d.action,
+                # ingress -> inbound(0), egress -> outbound(1)
+                deviceDirection: ( if $d.direction == "ingress" then 0
+                                   elif $d.direction == "egress" then 1
+                                   else null end ),
+                cn1: $s.packets,           cn1Label: "packets",
+                cn2: $s.droppedPackets,    cn2Label: "droppedPackets",
+                cn3: $s.bits,              cn3Label: "bits",
+                cs1: $d.attackId,          cs1Label: "attackId",
+                cs2: $d.attackType,        cs2Label: "attackType",
+                cs3: $d.attackVector,      cs3Label: "attackVector",
+                cs4: $d.mitigationType,    cs4Label: "mitigationType",
+                cs5: ( [ ($d.coloCity // ""), ($d.coloCountry // "") ] | map(select(. != "")) | join(", ") ),
+                cs5Label: "coloDatacenter",
+                externalId: $d.attackId
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-dns-records.yaml
+++ b/cef/v0/cloudflare/cloudflare-dns-records.yaml
@@ -1,0 +1,66 @@
+name: "Cloudflare DNS Records to CEF"
+description: "Maps Cloudflare DNS Records inventory into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-dns-records"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "dns-records"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare DNS Records -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Final-form values: severity 0-10, times epoch-MILLISECONDS,
+          # cs*/cn* slots always paired with their *Label. One jq pass;
+          # shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          def is_ip($s):
+            ($s | type) == "string"
+            and (($s | test("^[0-9]{1,3}(\\.[0-9]{1,3}){3}$")) or ($s | test(":")));
+
+          . as $r
+          | ($r.content // null) as $content
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "Cloudflare DNS",
+              version: "",
+              signature_id: ("dns.record." + ($r.type // "UNKNOWN")),
+              name: ("Cloudflare DNS " + ($r.type // "") + " record: " + ($r.name // "")),
+              severity: 2,
+              extension: ( {
+                rt:    to_epoch_ms($r.modified_on),
+                start: to_epoch_ms($r.created_on),
+                dhost: $r.name,
+                dst:   (if is_ip($content) then $content else null end),
+                externalId: $r.id,
+                outcome: "SUCCESS",
+                cn1: $r.ttl,
+                cn1Label: (if $r.ttl != null then "ttl" else null end),
+                cs1: $r.type,
+                cs1Label: (if $r.type != null then "recordType" else null end),
+                cs2: $r.zone_name,
+                cs2Label: (if $r.zone_name != null then "zoneName" else null end),
+                cs3: $content,
+                cs3Label: (if $content != null then "content" else null end),
+                cs4: (if $r.proxied != null then ($r.proxied | tostring) else null end),
+                cs4Label: (if $r.proxied != null then "proxied" else null end),
+                cs5: $r.zone_id,
+                cs5Label: (if $r.zone_id != null then "zoneId" else null end),
+                cs6: (if ($r.tags // []) | length > 0 then ($r.tags | join(",")) else null end),
+                cs6Label: (if ($r.tags // []) | length > 0 then "tags" else null end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-firewall-events.yaml
+++ b/cef/v0/cloudflare/cloudflare-firewall-events.yaml
@@ -1,0 +1,71 @@
+name: "Cloudflare Firewall Events to CEF"
+description: "Maps Cloudflare firewall_events (WAF / firewall rule matches) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-firewall-events"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "firewall-events"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare firewall_events -> CEF intermediate (T1). NO escaping.
+          # Final-form values: severity int 0-10; times epoch-MS; cs*/cn*
+          # slots paired with their *Label. One pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number"
+              then (if $ts > 1e12 then $ts elif $ts > 1e10 then ($ts*1000) else ($ts*1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          . as $r
+          | ($r.Action // "" | ascii_downcase) as $action
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "Cloudflare WAF",
+              version: "",
+              signature_id: (($r.RuleID // "") | if . == "" then ($r.Source // "firewall") else . end),
+              name: (($r.Description // "") | if . == "" then ("Cloudflare firewall " + ($r.Action // "event")) else . end),
+              severity: ( { "block":8, "drop":8, "connectionclose":8,
+                            "challenge":5, "managedchallenge":5, "jschallenge":5,
+                            "log":3, "allow":2, "bypass":2, "skip":2 }[$action] // 5 ),
+              extension: ( {
+                rt:      to_epoch_ms($r.Datetime),
+                src:     $r.ClientIP,
+                dhost:   $r.ClientRequestHost,
+                request: (if ($r.ClientRequestHost // "") != ""
+                          then (($r.ClientRequestScheme // "https") + "://" + $r.ClientRequestHost + ($r.ClientRequestPath // "") + ($r.ClientRequestQuery // "")) else null end),
+                requestMethod: $r.ClientRequestMethod,
+                requestClientApplication: $r.ClientRequestUserAgent,
+                app:     $r.ClientRequestScheme,
+                act:     $r.Action,
+                outcome: ($r.Action // null | if . == null then null else ascii_upcase end),
+                deviceExternalId: $r.RayID,
+                # custom slots (always paired with a *Label)
+                cs1Label: "SecuritySource",           cs1: $r.Source,
+                cs2Label: "RayID",                     cs2: $r.RayID,
+                cs3Label: "ClientCountry",             cs3: $r.ClientCountry,
+                cs4Label: "RulesetID",                 cs4: ($r.Metadata.ruleset_id // null),
+                cs5Label: "EdgeColoCode",              cs5: $r.EdgeColoCode,
+                cs6Label: "ClientIPClass",             cs6: $r.ClientIPClass,
+                cn1Label: "ClientASN",                 cn1: $r.ClientASN,
+                cn2Label: "EdgeResponseStatus",        cn2: (if ($r.EdgeResponseStatus // 0) > 0 then $r.EdgeResponseStatus else null end),
+                cn3Label: "OriginResponseStatus",      cn3: (if ($r.OriginResponseStatus // 0) > 0 then $r.OriginResponseStatus else null end)
+              }
+              | with_entries(select(.value != null and .value != ""))
+              # Drop any orphaned *Label whose paired value slot got pruned,
+              # so every custom slot stays label+value paired.
+              | ( . as $e
+                  | with_entries(select(
+                      (.key | endswith("Label") | not)
+                      or ($e[(.key | rtrimstr("Label"))] != null) )) ) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-http-requests.yaml
+++ b/cef/v0/cloudflare/cloudflare-http-requests.yaml
@@ -1,0 +1,93 @@
+name: "Cloudflare HTTP Requests to CEF"
+description: "Maps Cloudflare HTTP Requests (Logpush http_requests) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-http-requests"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "http-requests"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare HTTP Requests -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Final-form values: severity int 0-10; rt epoch-MILLISECONDS;
+          # every cs*/cn* slot paired with its *Label. One jq pass; shallow
+          # null-drop on the extension object (no recursive walk).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then ($ts/1e6 | floor) else ($ts * 1000 | floor) end)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ( ($r.EdgeResponseStatus // 0) | if type == "string" then tonumber else . end ) as $status
+          | ( ($r.SecurityAction // "") | ascii_downcase ) as $sec_action
+          | ( ($sec_action | test("block|challenge|drop|jschallenge|managed_challenge")) ) as $is_security
+          | {
+              _cef: {
+                vendor: "Cloudflare",
+                product: "Cloudflare HTTP Requests",
+                version: "",
+                # Low-cardinality event type: the security action when one fired,
+                # otherwise a generic request signature.
+                signature_id: ( if $sec_action != "" then $sec_action else "http.request" end ),
+                name: ( $r.SecurityRuleDescription
+                        // ( [ ($r.ClientRequestMethod // "GET"),
+                               ($r.ClientRequestHost // ""),
+                               ("(" + ($status | tostring) + ")") ] | join(" ") ) ),
+                severity: ( if ($sec_action | test("block|drop")) then 8
+                            elif ($sec_action | test("challenge")) then 6
+                            elif $status >= 500 then 6
+                            elif $status >= 400 then 4
+                            else 2 end ),
+                extension: ( {
+                  rt:      to_epoch_ms($r.EdgeStartTimestamp),
+                  end:     to_epoch_ms($r.EdgeEndTimestamp),
+                  src:     $r.ClientIP,
+                  spt:     $r.ClientSrcPort,
+                  dst:     $r.OriginIP,
+                  dhost:   $r.ClientRequestHost,
+                  app:     $r.ClientRequestScheme,
+                  requestMethod: $r.ClientRequestMethod,
+                  request: ( if $r.ClientRequestScheme != null and $r.ClientRequestHost != null and $r.ClientRequestURI != null
+                             then ($r.ClientRequestScheme + "://" + $r.ClientRequestHost + $r.ClientRequestURI)
+                             else $r.ClientRequestURI end ),
+                  requestClientApplication: $r.ClientRequestUserAgent,
+                  "in":    $r.ClientRequestBytes,
+                  "out":   $r.EdgeResponseBytes,
+                  act:     $r.SecurityAction,
+                  outcome: ( if $is_security or $status >= 400 then "FAILURE"
+                             elif $status > 0 then "SUCCESS" else null end ),
+                  # Custom slots — each *Label is gated on its value so a
+                  # missing value never leaves an orphan label behind.
+                  cn1: ( if $status > 0 then $status else null end ),
+                  cn1Label: ( if $status > 0 then "httpResponseStatus" else null end ),
+                  cn2: $r.WAFAttackScore,
+                  cn2Label: ( if $r.WAFAttackScore != null then "wafAttackScore" else null end ),
+                  cn3: $r.BotScore,
+                  cn3Label: ( if $r.BotScore != null then "botScore" else null end ),
+                  cs1: $r.RayID,
+                  cs1Label: ( if $r.RayID != null then "rayId" else null end ),
+                  cs2: ( $r.ClientCountry | if . == null then null else ascii_upcase end ),
+                  cs2Label: ( if $r.ClientCountry != null then "clientCountry" else null end ),
+                  cs3: $r.SecurityRuleID,
+                  cs3Label: ( if $r.SecurityRuleID != null then "securityRuleId" else null end ),
+                  cs4: $r.JA3Hash,
+                  cs4Label: ( if $r.JA3Hash != null then "ja3Hash" else null end ),
+                  cs5: $r.EdgeColoCode,
+                  cs5Label: ( if $r.EdgeColoCode != null then "edgeColo" else null end ),
+                  cs6: $r.CacheCacheStatus,
+                  cs6Label: ( if $r.CacheCacheStatus != null then "cacheStatus" else null end )
+                } | with_entries(select(.value != null and .value != "")) )
+              }
+            }

--- a/cef/v0/cloudflare/cloudflare-page-shield-connections.yaml
+++ b/cef/v0/cloudflare/cloudflare-page-shield-connections.yaml
@@ -1,0 +1,73 @@
+name: "Cloudflare Page Shield Connections to CEF"
+description: "Maps Cloudflare Page Shield connection records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-page-shield-connections"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "page-shield-connections"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare Page Shield connection -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2)
+          # owns all escaping. Emit FINAL-FORM values: severity int 0-10,
+          # times epoch-MILLISECONDS, custom cs* slots paired with *Label.
+          # One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          def truthy($v): ($v == true) or (($v|type) == "string" and ($v|ascii_downcase) == "true");
+          def cats($a): if ($a // []) | length > 0 then ($a | join(", ")) else null end;
+          def boolstr($v): if $v == null then null else ($v | tostring) end;
+
+          . as $r
+          | (truthy($r.domain_reported_malicious) or truthy($r.url_reported_malicious)) as $mal
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "Page Shield",
+              version: "",
+              signature_id: (if $mal then "page_shield.connection.malicious" else "page_shield.connection.detected" end),
+              name: (if $mal
+                     then ("Malicious Page Shield connection to " + ($r.host // "unknown host"))
+                     else ("Page Shield connection to " + ($r.host // "unknown host")) end),
+              severity: (if $mal then 8 else 3 end),
+              extension: ( {
+                rt:      to_epoch_ms($r.last_seen_at // $r.added_at),
+                start:   to_epoch_ms($r.first_seen_at),
+                end:     to_epoch_ms($r.last_seen_at),
+                request: $r.url,
+                dhost:   $r.host,
+                act:     "detect",
+                outcome: (if $mal then "MALICIOUS" else "OBSERVED" end),
+                reason:  ( [ cats($r.malicious_url_categories), cats($r.malicious_domain_categories) ]
+                           | map(select(. != null)) | if length > 0 then join("; ") else null end ),
+                msg:     (if $mal
+                          then ("Cloudflare Page Shield flagged an outbound connection to " + ($r.url // $r.host // "an external resource") + " as malicious.")
+                          else ("Cloudflare Page Shield observed an outbound connection to " + ($r.url // $r.host // "an external resource") + ".")
+                          end),
+                cs1: $r.id,
+                cs1Label: (if $r.id != null then "connectionId" else null end),
+                cs2: $r.first_page_url,
+                cs2Label: (if $r.first_page_url != null then "firstPageUrl" else null end),
+                cs3: boolstr($r.url_reported_malicious),
+                cs3Label: (if $r.url_reported_malicious != null then "urlReportedMalicious" else null end),
+                cs4: boolstr($r.domain_reported_malicious),
+                cs4Label: (if $r.domain_reported_malicious != null then "domainReportedMalicious" else null end),
+                cs5: boolstr($r.url_contains_cdn_cgi_path),
+                cs5Label: (if $r.url_contains_cdn_cgi_path != null then "urlContainsCdnCgiPath" else null end),
+                cn1: (($r.page_urls // []) | length),
+                cn1Label: "pageUrlCount"
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-rulesets.yaml
+++ b/cef/v0/cloudflare/cloudflare-rulesets.yaml
@@ -1,0 +1,52 @@
+name: "Cloudflare Rulesets to CEF"
+description: "Maps Cloudflare Rulesets inventory records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-rulesets"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "rulesets"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare Rulesets -> CEF intermediate (T1). No escaping here;
+          # the shared serializer (T2) owns all escaping. Emit FINAL-FORM:
+          #   severity int 0-10; times epoch-MS; cs*/cn* paired with *Label.
+          # Inventory records are informational -> severity 2.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.rules // []) as $rules
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "Cloudflare Rulesets",
+              version: ($r.version // ""),
+              signature_id: ($r.phase // "ruleset"),
+              name: ("Cloudflare ruleset: " + ($r.name // $r.id // "unknown")),
+              severity: 2,
+              extension: ( {
+                rt:         to_epoch_ms($r.last_updated),
+                externalId: $r.id,
+                msg:        ($r.description // $r.name),
+                cat:        "Asset Inventory",
+                cs1Label: "rulesetKind",  cs1: $r.kind,
+                cs2Label: "rulesetPhase", cs2: $r.phase,
+                cs3Label: "rulesetName",  cs3: $r.name,
+                cs4Label: "zoneId",       cs4: $r.zone_id,
+                cs5Label: "accountId",    cs5: $r.account_id,
+                cn1Label: "ruleCount",    cn1: ($rules | length)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-security-insights.yaml
+++ b/cef/v0/cloudflare/cloudflare-security-insights.yaml
@@ -1,0 +1,59 @@
+name: "Cloudflare Security Insights to CEF"
+description: "Maps Cloudflare Security Center Insights (security posture / misconfiguration findings) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-security-insights"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "security_insights"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare Security Center Insights -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2)
+          # owns all escaping. Emit FINAL-FORM values:
+          #   - severity: integer 0-10 (Low=3, Moderate=5, Critical=9)
+          #   - time fields (rt/start): epoch-MILLISECONDS
+          #   - custom slots cs*/cn* ALWAYS paired with their *Label
+          # One jq pass; drop nulls with a shallow with_entries on the
+          # extension object (no recursive walk).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ( $r.payload ) as $p
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "Cloudflare Security Center",
+              version: "",
+              signature_id: ($r.issue_type // "security_insight"),
+              name: ($r.resolve_text // $r.issue_type // "Cloudflare Security Insight"),
+              severity: ( { "Low": 3, "Moderate": 5, "Critical": 9 }[$r.severity] // 0 ),
+              extension: ( {
+                rt:      to_epoch_ms($r.timestamp),
+                start:   to_epoch_ms($r.since),
+                dhost:   $r.subject,
+                act:     $r.issue_type,
+                outcome: $r.status,
+                msg:     $r.resolve_text,
+                cs1Label: "issueClass",          cs1: $r.issue_class,
+                cs2Label: "zoneTag",             cs2: ( if ($p | type) == "object" then $p.zone_tag else null end ),
+                cs3Label: "detectionMethod",     cs3: ( if ($p | type) == "object" then $p.detection_method else null end ),
+                cs4Label: "userClassification",  cs4: $r.user_classification,
+                cs5Label: "insightId",           cs5: $r.id,
+                cs6Label: "resolveLink",         cs6: $r.resolve_link,
+                cn1Label: "dismissed",           cn1: ( if $r.dismissed == true then 1 elif $r.dismissed == false then 0 else null end )
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-url-scanner.yaml
+++ b/cef/v0/cloudflare/cloudflare-url-scanner.yaml
@@ -1,0 +1,71 @@
+name: "Cloudflare URL Scanner to CEF"
+description: "Maps Cloudflare URL Scanner scan-result records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-url-scanner"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "url-scanner"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare URL Scanner -> CEF intermediate (T1). No escaping here;
+          # the shared CEF Serializer (T2) owns all escaping. Emit final-form
+          # values: severity 0-10, times epoch-MILLISECONDS, custom slots
+          # paired with their *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.task // {}) as $t
+          | ($r.page // {}) as $p
+          | (($r.verdicts // {}).overall // {}) as $v
+          | (($v.malicious) == true) as $bad
+          | (($v.categories // []) | join(", ")) as $cats
+          | (($v.tags // []) | join(", ")) as $tags
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "URL Scanner",
+              version: "",
+              signature_id: (if $bad then "url.scan.malicious" else "url.scan.clean" end),
+              name: (if $bad
+                     then ("Malicious URL detected: " + ($t.url // ""))
+                     else ("URL scanned clean: " + ($t.url // "")) end),
+              severity: (if $bad then 8 else 2 end),
+              extension: ( {
+                rt:         to_epoch_ms($t.time),
+                request:    $t.url,
+                dhost:      $p.domain,
+                dst:        $p.ip,
+                act:        "url_scan",
+                outcome:    (if $t.success == true then "SUCCESS" else "FAILURE" end),
+                externalId: $t.uuid,
+                msg:        (if $bad
+                             then ("Cloudflare URL Scanner flagged " + ($t.url // "") + " as malicious")
+                             else ("Cloudflare URL Scanner found no threat for " + ($t.url // "")) end),
+                cn1:       $p.status,
+                cn1Label:  (if $p.status != null then "httpStatus" else null end),
+                cs1:       $cats,
+                cs1Label:  (if $cats != "" then "verdictCategories" else null end),
+                cs2:       $p.country,
+                cs2Label:  (if $p.country != null then "pageCountry" else null end),
+                cs3:       $tags,
+                cs3Label:  (if $tags != "" then "threatTags" else null end),
+                cs4:       $t.reportURL,
+                cs4Label:  (if $t.reportURL != null then "reportUrl" else null end),
+                cs5:       $p.asnname,
+                cs5Label:  (if $p.asnname != null then "asnName" else null end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-users.yaml
+++ b/cef/v0/cloudflare/cloudflare-users.yaml
@@ -1,0 +1,55 @@
+name: "Cloudflare Account Members to CEF"
+description: "Maps Cloudflare account member (user) inventory records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-users"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "users"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare account members -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # severity: integer 0-10 ; times: epoch-MILLISECONDS ; custom
+          # cs*/cn* slots always paired with their *Label. One jq pass;
+          # shallow with_entries null-drop on the extension object.
+          # ---------------------------------------------------------------
+          . as $r
+          | ($r.user // {}) as $u
+          | ($r.account // {}) as $acct
+          | ($r.email // $u.email) as $mail
+          | (([$u.first_name, $u.last_name] | map(select(. != null and . != "")) | join(" "))) as $full
+          | (($r.roles // []) | map(.name) | map(select(. != null)) | join(",")) as $roles
+          | { _cef: {
+              vendor:  "Cloudflare",
+              product: "Cloudflare Account Members",
+              version: "",
+              # Stable, low-cardinality event type keyed on membership status.
+              signature_id: ("cloudflare.account.member." + ($r.status // "unknown")),
+              name: ("Cloudflare account membership " + ($r.status // "unknown") + " for " + ($mail // ($r.id // "unknown"))),
+              # accepted -> Low(2); pending -> Medium(5); else informational.
+              severity: ( { "accepted": 2, "pending": 5 }[$r.status] // 1 ),
+              extension: ( {
+                rt:        (now * 1000 | floor),
+                duser:     $mail,
+                duid:      ($u.id // $r.id),
+                dvchost:   ($acct.name),
+                outcome:   (if $r.status == "accepted" then "SUCCESS"
+                            elif $r.status == "pending" then "PENDING"
+                            else "UNKNOWN" end),
+                cs1Label:  "membershipId",       cs1: $r.id,
+                cs2Label:  "roles",              cs2: (if $roles == "" then null else $roles end),
+                cs3Label:  "accountId",          cs3: $acct.id,
+                cs4Label:  "fullName",           cs4: (if $full == "" then null else $full end),
+                cs5Label:  "mfaEnabled",         cs5: ($u.two_factor_authentication_enabled | tostring)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-zerotrust-access-requests.yaml
+++ b/cef/v0/cloudflare/cloudflare-zerotrust-access-requests.yaml
@@ -1,0 +1,55 @@
+name: "Cloudflare Zero Trust Access Requests to CEF"
+description: "Maps Cloudflare Zero Trust Access authentication (access_requests) logs into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-zerotrust-access-requests"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "access-requests"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare Zero Trust Access access_requests -> CEF intermediate (T1).
+          # No escaping here (the shared serializer owns it). Final-form values:
+          #   severity int 0-10; times epoch-MS; custom slots paired with *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | (if $r.allowed == true then "SUCCESS"
+             elif $r.allowed == false then "FAILURE"
+             else "UNKNOWN" end) as $outcome
+          | (if $r.allowed == false then 6 else 2 end) as $sev
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "Cloudflare Zero Trust Access",
+              version: "",
+              signature_id: ($r.action // "access_request"),
+              name: ("Cloudflare Access " + ($r.action // "request")
+                     + " (" + ($outcome | ascii_downcase) + ")"),
+              severity: $sev,
+              extension: ( {
+                rt:      to_epoch_ms($r.created_at),
+                suser:   $r.user_email,
+                src:     $r.ip_address,
+                dhost:   $r.app_domain,
+                request: $r.app_domain,
+                act:     $r.action,
+                outcome: $outcome,
+                cs1Label: "idp",     cs1: $r.connection,
+                cs2Label: "appUid",  cs2: $r.app_uid,
+                cs3Label: "rayId",   cs3: $r.ray_id
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudflare/cloudflare-zones.yaml
+++ b/cef/v0/cloudflare/cloudflare-zones.yaml
@@ -1,0 +1,65 @@
+name: "Cloudflare Zones to CEF"
+description: "Maps Cloudflare Zones inventory records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudflare-zones"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudflare"
+  - "zones"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudflare Zone (GET /zones) -> CEF intermediate (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Final-form values: severity int 0-10; times epoch-MS; custom
+          # slots paired with *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.account // {}) as $acct
+          | ($r.plan // {}) as $plan
+          | ($r.meta // {}) as $meta
+          | { _cef: {
+              vendor: "Cloudflare",
+              product: "Cloudflare Zones",
+              version: "",
+              signature_id: "zone.inventory",
+              name: ("Cloudflare zone inventory: " + ($r.name // "unknown")),
+              # Not an alert stream — informational, escalated on risk signals.
+              severity: ( if ($meta.phishing_detected == true) then 8
+                          elif ($r.paused == true) then 4
+                          elif ($r.status != null and $r.status != "active") then 4
+                          else 2 end ),
+              # Each custom slot label+value is emitted as a unit so a label is
+              # never orphaned when its value is absent.
+              extension: ( (
+                { rt:      to_epoch_ms($r.modified_on // $r.created_on),
+                  start:   to_epoch_ms($r.created_on),
+                  end:     to_epoch_ms($r.activated_on),
+                  dhost:   $r.name,
+                  externalId: $r.id,
+                  act:     "zone-inventory",
+                  outcome: (if $r.status == "active" then "SUCCESS" else ($r.status // null) end) }
+                + (if $r.status then { cs1Label: "zoneStatus", cs1: $r.status } else {} end)
+                + (if $plan.name then { cs2Label: "zonePlan", cs2: $plan.name } else {} end)
+                + (if $r.type then { cs3Label: "zoneType", cs3: $r.type } else {} end)
+                + (if $acct.name then { cs4Label: "accountName", cs4: $acct.name } else {} end)
+                + ((($r.name_servers // []) | join(",")) as $ns | if $ns != "" then { cs5Label: "nameServers", cs5: $ns } else {} end)
+                + (if $r.original_registrar then { cs6Label: "originalRegistrar", cs6: $r.original_registrar } else {} end)
+                + (if $r.development_mode != null then { cn1Label: "developmentMode", cn1: $r.development_mode } else {} end)
+                + (if $meta.phishing_detected == true then { cfp1Label: "phishingDetected", cfp1: 1 } else {} end)
+              ) | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudsmith/cloudsmith-audit-logs.yaml
+++ b/cef/v0/cloudsmith/cloudsmith-audit-logs.yaml
@@ -1,0 +1,62 @@
+name: "Cloudsmith Audit Logs to CEF"
+description: "Maps Cloudsmith Audit Log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cloudsmith-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "cloudsmith"
+  - "audit-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Cloudsmith Audit Logs -> CEF intermediate (T1). No escaping here;
+          # the shared CEF Serializer (T2) owns all escaping/header assembly.
+          # severity: integer 0-10 bucketed from the verb; rt in epoch-ms;
+          # custom cs* slots always paired with their *Label. One jq pass.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.event // "") as $ev
+          | (
+              if ($ev|contains(".delete")) or ($ev|contains(".revoked")) or ($ev|contains(".removed")) then 6
+              elif ($ev|contains(".update")) or ($ev|contains(".changed")) or ($ev|contains(".refreshed")) or ($ev|contains(".rotated")) then 4
+              elif ($ev|endswith(".created")) or ($ev|contains(".create")) then 3
+              else 2 end
+            ) as $sev
+          | { _cef: {
+              vendor: "Cloudsmith",
+              product: "Cloudsmith Audit Logs",
+              version: "",
+              signature_id: $ev,
+              name: ([$r.actor, $ev, "on", $r.object] | map(select(. != null)) | join(" ")),
+              severity: $sev,
+              extension: ( {
+                rt:         to_epoch_ms($r.event_at),
+                suser:      $r.actor,
+                suid:       $r.actor_slug_perm,
+                src:        $r.actor_ip_address,
+                act:        $ev,
+                outcome:    "SUCCESS",
+                externalId: $r.uuid,
+                sourceServiceName: $r.context,
+                cs1Label: "object",       cs1: $r.object,
+                cs2Label: "objectKind",   cs2: $r.object_kind,
+                cs3Label: "target",       cs3: $r.target,
+                cs4Label: "targetKind",   cs4: $r.target_kind,
+                cs5Label: "actorKind",    cs5: $r.actor_kind,
+                cs6Label: "sourceCountry", cs6: ($r.actor_location.country_code // $r.actor_location.country)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cloudsmith/cloudsmith-audit-logs.yaml
+++ b/cef/v0/cloudsmith/cloudsmith-audit-logs.yaml
@@ -1,5 +1,5 @@
 name: "Cloudsmith Audit Logs to CEF"
-description: "Maps Cloudsmith Audit Log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+description: "Maps Cloudsmith audit log records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
 author: "Monad"
 contributors:
   - "https://github.com/behobu"
@@ -17,10 +17,10 @@ config:
         key: ""
         query: |
           # ---------------------------------------------------------------
-          # Cloudsmith Audit Logs -> CEF intermediate (T1). No escaping here;
-          # the shared CEF Serializer (T2) owns all escaping/header assembly.
-          # severity: integer 0-10 bucketed from the verb; rt in epoch-ms;
-          # custom cs* slots always paired with their *Label. One jq pass.
+          # Cloudsmith audit log -> CEF intermediate (T1). NO escaping here;
+          # the shared serializer (T2) owns all CEF escaping/header assembly.
+          # Emit final-form values: severity 0-10, times epoch-ms, every
+          # custom slot paired with its label.
           # ---------------------------------------------------------------
           def to_epoch_ms($ts):
             if $ts == null then null
@@ -29,34 +29,33 @@ config:
             end;
 
           . as $r
-          | ($r.event // "") as $ev
-          | (
-              if ($ev|contains(".delete")) or ($ev|contains(".revoked")) or ($ev|contains(".removed")) then 6
-              elif ($ev|contains(".update")) or ($ev|contains(".changed")) or ($ev|contains(".refreshed")) or ($ev|contains(".rotated")) then 4
-              elif ($ev|endswith(".created")) or ($ev|contains(".create")) then 3
-              else 2 end
-            ) as $sev
+          | ($r.event // "")       as $ev
+          | ($ev | ascii_downcase) as $evl
           | { _cef: {
               vendor: "Cloudsmith",
               product: "Cloudsmith Audit Logs",
               version: "",
-              signature_id: $ev,
-              name: ([$r.actor, $ev, "on", $r.object] | map(select(. != null)) | join(" ")),
-              severity: $sev,
+              signature_id: (if $ev != "" then $ev else "unknown" end),
+              name: ($ev
+                     + (if ($r.actor // "") != "" then " by " + $r.actor else "" end)
+                     + (if ($r.object // "") != "" then " on " + $r.object else "" end)),
+              severity: (if   ($evl | test("delet|remov|revok|destroy|purge")) then 6
+                         elif ($evl | test("creat|updat|chang|add|modif|set")) then 4
+                         else 3 end),
               extension: ( {
-                rt:         to_epoch_ms($r.event_at),
-                suser:      $r.actor,
-                suid:       $r.actor_slug_perm,
-                src:        $r.actor_ip_address,
-                act:        $ev,
-                outcome:    "SUCCESS",
-                externalId: $r.uuid,
-                sourceServiceName: $r.context,
-                cs1Label: "object",       cs1: $r.object,
-                cs2Label: "objectKind",   cs2: $r.object_kind,
-                cs3Label: "target",       cs3: $r.target,
-                cs4Label: "targetKind",   cs4: $r.target_kind,
-                cs5Label: "actorKind",    cs5: $r.actor_kind,
-                cs6Label: "sourceCountry", cs6: ($r.actor_location.country_code // $r.actor_location.country)
-              } | with_entries(select(.value != null and .value != "")) )
+                  rt: to_epoch_ms($r.event_at),
+                  suser: $r.actor,
+                  src: $r.actor_ip_address,
+                  act: $r.event,
+                  outcome: "Success",
+                  requestClientApplication: $r.actor_kind,
+                  externalId: $r.uuid
+                }
+                + (if ($r.context // "") != ""      then { cs1Label: "context",    cs1: $r.context }      else {} end)
+                + (if ($r.object_kind // "") != ""  then { cs2Label: "objectKind", cs2: $r.object_kind }  else {} end)
+                + (if ($r.object // "") != ""        then { cs3Label: "object",     cs3: $r.object }        else {} end)
+                + (if ($r.target // "") != ""        then { cs4Label: "target",     cs4: $r.target }        else {} end)
+                + (if ($r.target_kind // "") != ""   then { cs5Label: "targetKind", cs5: $r.target_kind }   else {} end)
+                + (if ($r.actor_location.country_code // "") != "" then { cs6Label: "actorCountry", cs6: $r.actor_location.country_code } else {} end)
+                | with_entries(select(.value != null and .value != "")) )
           } }

--- a/cef/v0/clumio/clumio-consolidated-alerts.yaml
+++ b/cef/v0/clumio/clumio-consolidated-alerts.yaml
@@ -1,0 +1,56 @@
+name: "Clumio Consolidated Alerts to CEF"
+description: "Maps Clumio consolidated alert records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "clumio-consolidated-alerts"
+tags:
+  - "v0"
+  - "cef"
+  - "clumio"
+  - "consolidated-alerts"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Clumio consolidated alert -> CEF intermediate (T1). No escaping.
+          # severity: integer 0-10; times epoch-ms; custom slots + labels.
+          # ---------------------------------------------------------------
+          . as $r
+          | ($r.parent_entity // {}) as $pe
+          | ($r.details // {}) as $d
+          | def to_epoch_ms($ts):
+              if $ts == null or $ts == "" then null
+              elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+              else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+              end;
+          { _cef: {
+              vendor: "Clumio",
+              product: "Clumio",
+              version: "",
+              signature_id: ($r.type // "alert"),
+              name: (($r.type // "Alert") + ": " + ($r.cause // "unknown")),
+              severity: ( { "error": 7, "warning": 4 }[($r.severity // "" | ascii_downcase)] // 0 ),
+              extension: ( {
+                rt:      to_epoch_ms($r.updated_timestamp // $r.raised_timestamp),
+                start:   to_epoch_ms($r.raised_timestamp),
+                end:     to_epoch_ms($r.cleared_timestamp),
+                act:     ($r.type // null),
+                outcome: ({ "active": "ACTIVE", "cleared": "CLEARED" }[($r.status // "" | ascii_downcase)] // null),
+                msg:     ($d.cause // $r.cause // null),
+                reason:  ($r.cause // null),
+                externalId: ($r.id // null),
+                cs1Label: "parentEntityType", cs1: ($pe.type // null),
+                cs2Label: "parentEntityName", cs2: ($pe.value // null),
+                cs3Label: "parentEntityId",   cs3: ($pe.id // null),
+                cs4Label: "alertStatus",      cs4: ($r.status // null),
+                cs5Label: "alertCause",       cs5: ($r.cause // null),
+                cs6Label: "notes",            cs6: ($r.notes // null),
+                cn1Label: "activeEntityCount", cn1: ($r.active_entity_count // null),
+                cn2Label: "clearedEntityCount", cn2: ($r.cleared_entity_count // null)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/clumio/clumio-individual-alerts.yaml
+++ b/cef/v0/clumio/clumio-individual-alerts.yaml
@@ -1,0 +1,58 @@
+name: "Clumio Individual Alerts to CEF"
+description: "Maps Clumio Individual Alert records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "clumio-individual-alerts"
+tags:
+  - "v0"
+  - "cef"
+  - "clumio"
+  - "individual-alerts"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Clumio Individual Alert -> CEF intermediate (T1). No escaping here;
+          # the shared CEF Serializer (T2) owns all escaping. Final-form values:
+          #   severity int 0-10; time fields epoch-MILLISECONDS; cs*/cn* + labels.
+          # One jq pass, shallow null-drop on the extension object only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.primary_entity // {}) as $pe
+          | ($r.details // {}) as $d
+          | { _cef: {
+              vendor: "Clumio",
+              product: "Clumio",
+              version: "",
+              signature_id: ($r.type // "clumio_alert"),
+              name: ($r.cause // $d.cause // "Clumio Alert"),
+              severity: ( { "error": 7, "warning": 4 }[$r.severity] // 0 ),
+              extension: ( {
+                rt:         to_epoch_ms($r.raised_timestamp),
+                end:        to_epoch_ms($r.cleared_timestamp),
+                externalId: ($r.id // null),
+                cat:        ($r.type // null),
+                act:        ($r.type // null),
+                outcome:    ($r.status // null),
+                msg:        ($d.description // null),
+                reason:     ($r.cause // null),
+                cnt:        ($r.raised_count // null),
+                cs1Label:   "primaryEntityType",  cs1: ($pe.type // null),
+                cs2Label:   "primaryEntityValue", cs2: ($pe.value // null),
+                cs3Label:   "primaryEntityId",    cs3: ($pe.id // null),
+                cs4Label:   "consolidatedAlertId", cs4: ($r.consolidated_alert_id // null),
+                cs5Label:   "alertStatus",        cs5: ($r.status // null),
+                cs6Label:   "cloudAccountId",     cs6: ($d.variables.account_native_id // null | tostring)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/coda/coda-audit-events.yaml
+++ b/cef/v0/coda/coda-audit-events.yaml
@@ -1,0 +1,58 @@
+name: "Coda Audit Events to CEF"
+description: "Maps Coda Admin Audit API events into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "coda-audit-events"
+tags:
+  - "v0"
+  - "cef"
+  - "coda"
+  - "audit-events"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Coda Admin Audit API event -> CEF intermediate (T1).
+          # No escaping here (T2 serializer owns it). Final-form values:
+          #   severity integer 0-10; times epoch-MILLISECONDS;
+          #   custom cs* slots always paired with their *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+              if $ts == null then null
+              elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+              else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+              end;
+          . as $r
+          | ($r.action // "") as $action
+          | ($r.result // "") as $result
+          # denied/blocked -> higher severity; login/logout are informational
+          | (if   ($result | ascii_downcase) != "allowed" and $result != "" then 6
+             elif $action == "LogInUser" or $action == "LogOutUser" then 2
+             else 3 end) as $severity
+          | { _cef: {
+              vendor: "Coda",
+              product: "Coda Admin Audit",
+              version: "",
+              signature_id: $action,
+              name: ($action + " (" + $result + ")"),
+              severity: $severity,
+              extension: ( {
+                rt:      to_epoch_ms($r.timestamp),
+                suser:   $r.user.email,
+                suid:    (if $r.user.id != null then ($r.user.id | tostring) else null end),
+                src:     $r.userContext.ipAddress,
+                act:     $action,
+                outcome: $result,
+                requestClientApplication: $r.userContext.browser.ua,
+                cs1Label: "sessionId",      cs1: $r.userContext.sessionId,
+                cs2Label: "clientSource",   cs2: $r.userContext.source,
+                cs3Label: "organizationId", cs3: $r.organizationId,
+                cs4Label: "providerName",   cs4: $r.eventDetails.providerName,
+                cs5Label: "entityType",     cs5: $r.entity.type
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/cursor/cursor-audit-logs.yaml
+++ b/cef/v0/cursor/cursor-audit-logs.yaml
@@ -1,0 +1,48 @@
+name: "Cursor Audit Logs to CEF"
+description: "Maps Cursor team audit-log events into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "cursor-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "cursor"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # Cursor audit event -> CEF intermediate (T1). No escaping here — the
+          # shared serializer owns that. signature_id = the audited action.
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000) end;
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^(\\d{1,3}\\.){3}\\d{1,3}$") or (test(":") and test("^[0-9A-Fa-f:.]+$")));
+          def real($s): if ($s | type) == "string" and $s != "unknown" and $s != "" then $s else null end;
+          . as $r
+          | ( (.event_type // "") ) as $et
+          | { _cef: {
+              vendor: "Cursor",
+              product: "Cursor Audit Logs",
+              version: "",
+              signature_id: $r.event_type,
+              name: $r.event_type,
+              severity: (if ($et | test("(protected_git_scope|service_account|cloud_agent_secret|privacy_mode|api_key)")) then 6 else 3 end),
+              extension: ( {
+                rt: to_epoch_ms($r.timestamp),
+                suser: real($r.user_email),
+                suid: real($r.user_id),
+                src: (if is_ip($r.ip_address) then $r.ip_address else null end),
+                act: $r.event_type,
+                cs1Label: "teamId", cs1: $r.team_id,
+                cs2Label: "requestId", cs2: $r.request_id,
+                cs3Label: "sourceRaw", cs3: ($r.ip_address // null)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/endor-labs/endor-labs-audit-logs.yaml
+++ b/cef/v0/endor-labs/endor-labs-audit-logs.yaml
@@ -1,0 +1,66 @@
+name: "Endor Labs Audit Logs to CEF"
+description: "Maps Endor Labs Audit Log (AuditLog) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "endor-labs-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "endor-labs"
+  - "audit"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Endor Labs AuditLog -> CEF intermediate (T1). No escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. Final-form values:
+          #   severity integer 0-10; rt epoch-MILLISECONDS; cs* paired w/ label.
+          # One jq pass; shallow null-drop on the extension object only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          def email_of($cb):
+            if $cb == null then null
+            else ($cb | split("@")) as $p
+              | (if ($p | length) >= 2 then ($p[0] + "@" + $p[1]) else $cb end)
+            end;
+
+          # Higher severity for destructive ops.
+          def sev($op):
+            { "OPERATION_DELETE": 7, "OPERATION_CREATE": 5,
+              "OPERATION_UPDATE": 5, "OPERATION_UPSERT": 5,
+              "OPERATION_READ": 3 }[$op] // 4;
+
+          . as $r
+          | ($r.meta // {}) as $m
+          | ($r.spec // {}) as $s
+          | (email_of($m.created_by)) as $email
+          | { _cef: {
+                vendor: "Endor Labs",
+                product: "Endor Labs Audit Log",
+                version: "",
+                signature_id: ($s.operation // "OPERATION_UNSPECIFIED"),
+                name: (($s.operation // "operation") + " " + ($s.message_kind // "resource")),
+                severity: sev($s.operation),
+                extension: ( {
+                    rt:       to_epoch_ms($m.create_time // $m.upsert_time // $m.update_time),
+                    suser:    ($email // $m.created_by),
+                    src:      ($s.remote_address),
+                    act:      ($s.operation),
+                    outcome:  "SUCCESS",
+                    cs1Label: "resourceKind", cs1: ($s.message_kind),
+                    cs2Label: "resourceUuid", cs2: ($s.message_uuid),
+                    cs3Label: "namespace",    cs3: ($r.tenant_meta.namespace),
+                    cs4Label: "createdBy",    cs4: ($m.created_by),
+                    cs5Label: "auditUuid",    cs5: ($r.uuid)
+                  } | with_entries(select(.value != null and .value != "")) )
+            } }

--- a/cef/v0/github/github-advisory-db.yaml
+++ b/cef/v0/github/github-advisory-db.yaml
@@ -1,0 +1,86 @@
+name: "GitHub Advisory Database to CEF"
+description: "Maps GitHub Advisory Database (Global Security Advisory) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "github-advisory-db"
+tags:
+  - "v0"
+  - "cef"
+  - "github"
+  - "advisory"
+  - "vulnerability"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # GitHub Advisory Database -> CEF intermediate (T1).
+          # Input: ONE GitHub Global Security Advisory record per invocation.
+          # No escaping here — the shared CEF Serializer (T2) owns all
+          # escaping. Emit FINAL-FORM values: severity as integer 0-10, time
+          # fields as epoch-MILLISECONDS, every cs*/cn*/cfp* slot paired with
+          # its label. One jq pass; shallow null-drop on `extension`.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          # GHSA severity label -> CEF severity bucket (integer 0-10).
+          def sev_bucket:
+            (. // "" | ascii_downcase) as $s |
+            if   $s == "low"       then 3
+            elif $s == "medium" or $s == "moderate" then 5
+            elif $s == "high"      then 8
+            elif $s == "critical"  then 10
+            else 0 end;
+
+          # A custom slot only exists when it has a value: emit {slotLabel,slot}
+          # together or neither, so no orphaned *Label survives the null-drop.
+          def slot($n; $label; $val):
+            if $val == null or $val == "" then {}
+            else { ($n + "Label"): $label, ($n): $val } end;
+
+          def joined($arr): ($arr | join(", ") | (if . == "" then null else . end));
+
+          . as $r
+          | ($r.vulnerabilities // []) as $vulns
+          | ($r.cwes // []) as $cwes
+          | (($r.cvss_severities.cvss_v3 // $r.cvss // {})) as $cv
+          | { _cef: {
+              vendor: "GitHub",
+              product: "GitHub Advisory Database",
+              version: "",
+              # Stable, low-cardinality identifier: prefer GHSA (always
+              # present), fall back to CVE.
+              signature_id: ($r.ghsa_id // $r.cve_id),
+              name: $r.summary,
+              severity: ($r.severity | sev_bucket),
+              extension: ( ( {
+                # rt = published; end = last updated (epoch-ms).
+                rt:      to_epoch_ms($r.published_at),
+                end:     to_epoch_ms($r.updated_at),
+                msg:     $r.description,
+                request: $r.html_url,
+                reason:  $r.severity
+              }
+              # Custom slots (each label emitted only alongside its value).
+              + slot("cs1"; "ghsaId"; $r.ghsa_id)
+              + slot("cs2"; "cveId"; $r.cve_id)
+              + slot("cs3"; "cweIds"; joined([ $cwes[]?.cwe_id ]))
+              + slot("cs4"; "affectedPackages";
+                     joined([ $vulns[]? | (.package.ecosystem // "?") + ":" + (.package.name // "?")
+                              + " " + (.vulnerable_version_range // "*") ]))
+              + slot("cs5"; "cvssVector"; $cv.vector_string)
+              + slot("cs6"; "fixedVersions";
+                     joined([ $vulns[]? | select(.first_patched_version != null)
+                              | (.package.name // "package") + " " + .first_patched_version ]))
+              # CVSS base score as a floating-point custom slot.
+              + (if $cv.score == null then {} else { cfp1Label: "cvssBaseScore", cfp1: $cv.score } end)
+              ) | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/github/github-copilot-logs.yaml
+++ b/cef/v0/github/github-copilot-logs.yaml
@@ -1,0 +1,61 @@
+name: "GitHub Copilot Logs to CEF"
+description: "Maps GitHub Copilot activity records (from GitHub Enterprise audit logs) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "github-copilot-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "github"
+  - "copilot"
+  - "audit-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # GitHub audit logs -> CEF intermediate (T1). No escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. Final-form
+          # values: severity int 0-10, times epoch-MILLISECONDS, custom
+          # slots paired with *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          . as $r
+          | def to_epoch_ms($ts):
+              if $ts == null then null
+              elif ($ts | type) == "number" then (if $ts > 1e12 then ($ts | floor) else (($ts * 1000) | floor) end)
+              else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+              end;
+
+          # operation_type -> coarse severity bucket (0-10).
+          ( { "remove": 6, "modify": 5, "create": 4, "transfer": 6,
+                "authentication": 3, "access": 2 }[$r.operation_type] // 3 ) as $sev
+
+          | { _cef: {
+              vendor: "GitHub",
+              product: "GitHub Audit Log",
+              version: "",
+              signature_id: $r.action,
+              name: (($r.actor // "?") + " " + ($r.action // "?")),
+              severity: $sev,
+              extension: ( {
+                rt:       to_epoch_ms($r.created_at // $r["@timestamp"]),
+                suser:    $r.actor,
+                suid:     (if $r.actor_id != null then ($r.actor_id | tostring) else null end),
+                src:      $r.actor_ip,
+                duser:    $r.user,
+                duid:     (if $r.user_id != null then ($r.user_id | tostring) else null end),
+                act:      $r.action,
+                outcome:  "SUCCESS",
+                requestClientApplication: $r.user_agent,
+                cs1Label: "org",            cs1:  $r.org,
+                cs2Label: "repository",     cs2:  ($r.repo // $r.repository),
+                cs3Label: "team",           cs3:  $r.team,
+                cs4Label: "operationType",  cs4:  $r.operation_type,
+                cs5Label: "actorCountry",   cs5:  $r.actor_location.country_code,
+                cs6Label: "documentId",     cs6:  $r._document_id
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/gitlab/gitlab-issues.yaml
+++ b/cef/v0/gitlab/gitlab-issues.yaml
@@ -1,0 +1,65 @@
+name: "GitLab Issues to CEF"
+description: "Maps GitLab Issues API records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "gitlab-issues"
+tags:
+  - "v0"
+  - "cef"
+  - "gitlab"
+  - "issues"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # -----------------------------------------------------------------
+          # GitLab Issues API record -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values: severity 0-10, times epoch-ms,
+          # every cs*/cn* slot paired with its *Label. One jq pass; shallow
+          # null-drop on the extension object only (no recursive walk).
+          # -----------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000) end;
+
+          # GitLab issue severity -> CEF severity bucket (0-10).
+          def sev_cef($s):
+            ({ "critical": 9, "high": 7, "medium": 5, "low": 3, "unknown": 2 }
+              [($s // "" | ascii_downcase)] // 2);
+
+          . as $r
+          | ($r.author // {}) as $au
+          | (($r.assignees // [])[0] // $r.assignee // {}) as $asg
+          | (if ($r.created_at == $r.updated_at) then "create" else "update" end) as $verb
+          | { _cef: {
+                vendor: "GitLab",
+                product: "GitLab Issues",
+                version: "",
+                signature_id: (($r.issue_type // $r.type // "issue") + "." + $verb),
+                name: $r.title,
+                severity: sev_cef($r.severity),
+                extension: ( {
+                  rt:         to_epoch_ms($r.updated_at // $r.created_at),
+                  start:      to_epoch_ms($r.created_at),
+                  end:        to_epoch_ms($r.closed_at),
+                  suser:      $au.username,
+                  duser:      $asg.username,
+                  act:        $verb,
+                  outcome:    $r.state,
+                  externalId: (if $r.id != null then ($r.id | tostring) else null end),
+                  request:    $r.web_url,
+                  msg:        $r.description,
+                  cs1Label: "labels",       cs1: (($r.labels // []) | join(",")),
+                  cs2Label: "issueType",    cs2: ($r.issue_type // $r.type),
+                  cs3Label: "state",        cs3: $r.state,
+                  cs4Label: "confidential", cs4: (if $r.confidential != null then ($r.confidential | tostring) else null end),
+                  cn1Label: "iid",          cn1: $r.iid,
+                  cn2Label: "projectId",    cn2: $r.project_id
+                } | with_entries(select(.value != null and .value != "")) )
+            } }

--- a/cef/v0/glean/glean-assistant-insights.yaml
+++ b/cef/v0/glean/glean-assistant-insights.yaml
@@ -1,0 +1,65 @@
+name: "Glean Assistant Insights to CEF"
+description: "Maps Glean Assistant Insights interaction records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "glean-assistant-insights"
+tags:
+  - "v0"
+  - "cef"
+  - "glean"
+  - "assistant"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Glean Assistant Insights -> CEF intermediate (T1). NO escaping
+          # here (the shared serializer owns it). Final-form values only:
+          # severity integer 0-10, times epoch-MILLISECONDS, every cs*/cn*/
+          # flexString* slot paired with its *Label. One jq pass; shallow
+          # null-drop on the extension object (no recursive walk).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          def truthy($v): ($v == true) or (($v | type) == "string" and ($v | ascii_downcase) == "true");
+          def is_ip($s):
+            ($s | type) == "string"
+            and ($s | test("^[0-9]{1,3}(\\.[0-9]{1,3}){3}$") or test("^[0-9a-fA-F:]+:[0-9a-fA-F:]+$"));
+
+          . as $r
+          | (truthy($r.hadError)) as $err
+          | (($r.feedback // "") | ascii_upcase) as $fb
+          | { _cef: {
+              vendor: "Glean",
+              product: "Glean Assistant",
+              version: ($r.clientVersion // ""),
+              signature_id: ($r.feature // "assistant.chat"),
+              name: ("Glean Assistant " + ($r.feature // "interaction")),
+              severity: (if $err then 7 elif $fb == "NEGATIVE" then 5 else 3 end),
+              extension: ( {
+                rt:      to_epoch_ms($r.timestamp),
+                suser:   $r.userEmail,
+                suid:    $r.userId,
+                src:     (if is_ip($r.sourceIp) then $r.sourceIp else null end),
+                act:     ($r.feature // "chat"),
+                outcome: (if $err then "FAILURE" else "SUCCESS" end),
+                requestClientApplication: $r.userAgent,
+                cs1Label: "platform",       cs1: $r.platform,
+                cs2Label: "initiator",      cs2: $r.initiator,
+                cs3Label: "chatSessionId",  cs3: $r.chatSessionId,
+                cs4Label: "query",          cs4: $r.userQuery,
+                cs5Label: "model",          cs5: $r.modelName,
+                cs6Label: "department",     cs6: $r.department,
+                cn1Label: "inputTokens",    cn1: $r.inputTokens,
+                cn2Label: "outputTokens",   cn2: $r.outputTokens,
+                cn3Label: "responseMillis", cn3: $r.totalResponseMillis,
+                flexString1Label: "feedback", flexString1: $r.feedback
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/glean/glean-overview-insights.yaml
+++ b/cef/v0/glean/glean-overview-insights.yaml
@@ -1,0 +1,64 @@
+name: "Glean Overview Insights to CEF"
+description: "Maps Glean Overview Insights usage/adoption snapshot records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "glean-overview-insights"
+tags:
+  - "v0"
+  - "cef"
+  - "glean"
+  - "overview-insights"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Glean Overview Insights -> CEF intermediate (T1). No escaping here
+          # (the shared serializer owns it). Emit final-form values: severity
+          # integer 0-10, rt epoch-MILLISECONDS, every cs*/cn* paired with a
+          # *Label. One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          # Pair a custom slot with its label only when the value is present, so
+          # a missing field never emits a dangling label or a "null" string.
+          def pair($slot; $label; $v): if $v == null or $v == "" then {} else {($slot): $v, ($slot+"Label"): $label} end;
+          # spair: same, but stringifies a non-null numeric before pairing.
+          def spair($slot; $label; $v): if $v == null then {} else {($slot): ($v|tostring), ($slot+"Label"): $label} end;
+
+          . as $r
+          | ($r.monthlyActiveUserTimeseries.countInfo[-1].organization
+             // $r.weeklyActiveUserTimeseries.countInfo[-1].organization) as $org
+          | ($r.departments // [] | join(",")) as $depts
+          | { _cef: {
+              vendor: "Glean",
+              product: "Glean Overview Insights",
+              version: "",
+              signature_id: "overview.insights.snapshot",
+              name: "Glean Overview Insights Snapshot",
+              # Informational analytics snapshot -> low severity bucket.
+              severity: 2,
+              extension: ( ( {
+                  rt:      to_epoch_ms($r.lastUpdatedTs),
+                  outcome: "SUCCESS",
+                  act:     "overview.insights.snapshot",
+                  dvchost: $org
+                }
+                + pair("cn1"; "monthlyActiveUsers";        $r.monthlyActiveUsers)
+                + pair("cn2"; "weeklyActiveUsers";         $r.weeklyActiveUsers)
+                + pair("cn3"; "totalSignups";              $r.totalSignups)
+                + pair("cs1";  "organization";              $org)
+                + spair("cs2"; "employeeCount";             $r.employeeCount)
+                + spair("cs3"; "searchSessionSatisfaction"; $r.searchSessionSatisfaction)
+                + pair("cs4";  "departments";               $depts)
+                + spair("cs5"; "numSearches";               $r.searchSummary.numSearches)
+                + spair("cs6"; "numChats";                  $r.chatSummary.numChats)
+              ) | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/google/google-workspace-gemini-activity.yaml
+++ b/cef/v0/google/google-workspace-gemini-activity.yaml
@@ -1,0 +1,62 @@
+name: "Google Workspace Gemini Activity to CEF"
+description: "Maps Google Workspace Admin SDK Reports 'gemini_in_workspace_apps' activity records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "google-workspace-gemini-activity"
+tags:
+  - "v0"
+  - "cef"
+  - "google"
+  - "gemini-activity"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Google Workspace "gemini_in_workspace_apps" activity -> CEF (T1).
+          # No escaping here — the shared CEF Serializer (T2) owns escaping.
+          # Final-form values: severity 0-10, times epoch-MS, custom slots
+          # paired with their *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.id // {}) as $id
+          | ($r.actor // {}) as $ac
+          | ($r.events[0] // {}) as $ev
+          | ((($ev.parameters // []) | map({ (.name): (.value // .boolValue // .intValue // .multiValue) }) | add) // {}) as $p
+
+          | { _cef: {
+                vendor: "Google",
+                product: "Gemini in Workspace Apps",
+                version: "",
+                signature_id: ($ev.name // "feature_utilization"),
+                name: ("Gemini " + ($p.action // "feature") + " in " + ($p.app_name // "workspace")),
+                severity: 2,
+                extension: ( {
+                  rt:       to_epoch_ms($id.time),
+                  suser:    ($ac.email // null),
+                  suid:     ($ac.profileId // null),
+                  src:      ($r.ipAddress // null),
+                  act:      ($p.action // null),
+                  outcome:  "SUCCESS",
+                  cs1Label: "app_name",
+                  cs1: ($p.app_name // null),
+                  cs2Label: "feature_source",
+                  cs2: ($p.feature_source // null),
+                  cs3Label: "event_category",
+                  cs3: ($p.event_category // null),
+                  cs4Label: "ownerDomain",
+                  cs4: ($r.ownerDomain // null),
+                  cs5Label: "customerId",
+                  cs5: ($id.customerId // null)
+                } | with_entries(select(.value != null and .value != "")) )
+            } }

--- a/cef/v0/microsoft/microsoft-azure-virtual-machine.yaml
+++ b/cef/v0/microsoft/microsoft-azure-virtual-machine.yaml
@@ -1,0 +1,70 @@
+name: "Microsoft Azure Virtual Machine to CEF"
+description: "Maps Microsoft Azure Compute Virtual Machine (Get/List) inventory records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "microsoft-azure-virtual-machine"
+tags:
+  - "v0"
+  - "cef"
+  - "microsoft"
+  - "azure"
+  - "device"
+  - "inventory"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Microsoft Azure Virtual Machine -> CEF intermediate (T1).
+          # Emits FINAL-FORM values; does NO escaping (the shared CEF
+          # Serializer T2 owns all escaping/header assembly).
+          #   - severity: integer 0-10 (VM inventory is informational)
+          #   - rt: epoch-MILLISECONDS
+          #   - custom slots cs*/cn* always paired with their *Label
+          # One jq pass; shallow null-drop on the extension object.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else
+              ( ( ( $ts
+                    | gsub("\\.[0-9]+"; "")
+                    | sub("([+-][0-9]{2}:[0-9]{2}|Z)$"; "") )
+                  + "Z" | fromdateiso8601 ) * 1000 )
+            end;
+
+          . as $r
+          | ($r.properties // {}) as $p
+          | (($r.id // "") | split("/")) as $idp
+          | ($p.storageProfile.imageReference // {}) as $img
+          | ( $p.osProfile.computerName // $r.name ) as $host
+          | { _cef: {
+              vendor: "Microsoft",
+              product: "Azure Virtual Machines",
+              version: "",
+              signature_id: "azure:virtual-machine",
+              name: ("Azure VM inventory: " + ($host // "unknown host")),
+              # Inventory is informational; a non-Succeeded provisioning state
+              # is a degraded/notable condition, so bump the severity.
+              severity: ( if ($p.provisioningState // "Succeeded") == "Succeeded" then 2 else 6 end ),
+              extension: ( {
+                rt:               to_epoch_ms($p.timeCreated),
+                dvchost:          $host,
+                deviceExternalId: $p.vmId,
+                externalId:       $p.vmId,
+                suser:            $p.osProfile.adminUsername,
+                outcome:          $p.provisioningState,
+                sourceServiceName: "Azure Virtual Machines",
+                cs1Label: "osType",         cs1: $p.storageProfile.osDisk.osType,
+                cs2Label: "vmSize",         cs2: $p.hardwareProfile.vmSize,
+                cs3Label: "region",         cs3: $r.location,
+                cs4Label: "imageSku",       cs4: $img.sku,
+                cs5Label: "subscriptionId", cs5: ($idp[2]?),
+                cs6Label: "resourceGroup",  cs6: ($idp[4]?),
+                cn1Label: "vCPUs",          cn1: ($p.hardwareProfile.vmSizeProperties.vCPUsAvailable)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/mlflow/mlflow-genai-traces.yaml
+++ b/cef/v0/mlflow/mlflow-genai-traces.yaml
@@ -1,0 +1,81 @@
+name: "MLflow GenAI Traces to CEF"
+description: "Maps one MLflow GenAI trace into the normalized {_cef:{...}} CEF intermediate (Vendor=MLflow). Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "mlflow-genai-traces"
+tags:
+  - "v0"
+  - "cef"
+  - "mlflow"
+  - "genai"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # MLflow GenAI Trace -> CEF intermediate (T1). No escaping here —
+          # the shared CEF Serializer (T2) owns all escaping. Emit FINAL-FORM:
+          #   severity integer 0-10; time fields epoch-MILLISECONDS (MLflow
+          #   request_time is already epoch-ms); custom slots cs*/cn* paired
+          #   with their *Label. One jq pass; shallow null-drop; no walk.
+          #
+          # MLflow serializes attribute VALUES as JSON strings, so reads go
+          # through pj() (parse-json-string-or-passthrough).
+          # ---------------------------------------------------------------
+          def pj($v):
+            if $v == null then null
+            elif ($v | type) == "string" then ($v | fromjson? // $v)
+            else $v end;
+          def sattr($sp; $k): (($sp.attributes // {})[$k]) | pj(.);
+          def mattr($i; $k):  (($i.trace_metadata // {})[$k]) | pj(.);
+
+          . as $t
+          | ($t.info // {}) as $i
+          | ($t.data.spans // []) as $spans
+          | ( $spans | map(select(((.span_type // "") | ascii_upcase) as $st
+                          | $st == "LLM" or $st == "CHAT_MODEL")) | (.[0] // null) ) as $llm
+          | ( $spans | map(select(.parent_span_id == null)) | (.[0] // null) ) as $root
+
+          | ( mattr($i; "mlflow.trace.tokenUsage") ) as $ttok
+          | ( if $llm != null then sattr($llm; "mlflow.chat.tokenUsage") else null end ) as $stok
+          | ( (if ($ttok | type) == "object" then $ttok.input_tokens else null end)
+              // (if ($stok | type) == "object" then $stok.input_tokens else null end) ) as $in_tok
+          | ( (if ($ttok | type) == "object" then $ttok.output_tokens else null end)
+              // (if ($stok | type) == "object" then $stok.output_tokens else null end) ) as $out_tok
+
+          | ( if $llm != null then (sattr($llm; "gen_ai.request.model") // sattr($llm; "gen_ai.response.model") // sattr($llm; "mlflow.chat.model")) else null end ) as $model
+          | ( $i.state // "STATE_UNSPECIFIED" ) as $state
+          | ( mattr($i; "mlflow.trace.user") ) as $user_id
+          | ( mattr($i; "mlflow.trace.session") ) as $sess
+          | ( $i.trace_location // {} ) as $loc
+          | ( ($root.span_type // "GENAI") | ascii_downcase ) as $stype
+          | ( $root.name // ($i.tags."mlflow.traceName") // "genai.trace" ) as $op
+
+          | { _cef: {
+                vendor: "MLflow",
+                product: "MLflow GenAI Traces",
+                version: "",
+                signature_id: ("genai." + $stype),
+                name: ("MLflow trace " + $op + " (" + $state + ")"),
+                severity: ( { "OK": 2, "IN_PROGRESS": 4, "ERROR": 7, "STATE_UNSPECIFIED": 0 }[$state] // 0 ),
+                extension: ( {
+                  rt:      $i.request_time,
+                  end:     (if ($i.request_time != null and $i.execution_duration != null)
+                            then ($i.request_time + $i.execution_duration) else null end),
+                  outcome: $state,
+                  act:     $op,
+                  suser:   $user_id,
+                  msg:     $i.request_preview,
+                  cs1Label: "traceId",       cs1: $i.trace_id,
+                  cs2Label: "model",         cs2: $model,
+                  cs3Label: "sessionId",     cs3: $sess,
+                  cs4Label: "experimentId",  cs4: ($loc.mlflow_experiment.experiment_id),
+                  cn1Label: "executionMs",   cn1: $i.execution_duration,
+                  cn2Label: "inputTokens",   cn2: $in_tok,
+                  cn3Label: "outputTokens",  cn3: $out_tok
+                } | with_entries(select(.value != null and .value != "")) )
+            } }

--- a/cef/v0/openai/openai-codex.yaml
+++ b/cef/v0/openai/openai-codex.yaml
@@ -1,0 +1,115 @@
+name: "OpenAI Codex (OTLP) to CEF"
+description: "Maps OTLP telemetry from OpenAI Codex into the normalized {_cef} intermediate (T1) consumed by the shared CEF serializer, fanning out one CEF event per OTLP logRecord. Emits vendor/product/signature/name/severity plus dictionary keys (rt, suser, act, outcome, reason) and labeled custom slots for conversation id, model, tool name and token counts. No escaping is performed here (the serializer owns it)."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "openai-codex"
+tags:
+  - "v0"
+  - "cef"
+  - "openai"
+  - "codex"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # -----------------------------------------------------------------
+          # OpenAI Codex RAW OTLP logs -> CEF T1 intermediate ({_cef})
+          # One OTLP envelope in -> one {_cef} per logRecord out.
+          # Metrics envelopes produce no output. NO escaping here (T2 owns it).
+          # Severity buckets (0-10): api/tool error or denied decision -> 6;
+          # sandbox non-success -> 5; success -> 2; default -> 3.
+          # -----------------------------------------------------------------
+
+          def num($x):
+            if $x == null or $x == "" then null
+            elif ($x | type) == "string" then ($x | tonumber? // null)
+            else $x end;
+          def truthy($v): ($v == true) or (($v | type) == "string" and ($v | ascii_downcase) == "true");
+
+          def av($v):
+            if $v == null then null
+            elif $v.stringValue != null then $v.stringValue
+            elif $v.intValue != null then ($v.intValue | tonumber)
+            elif $v.doubleValue != null then $v.doubleValue
+            elif $v.boolValue != null then $v.boolValue
+            elif $v.arrayValue != null then ((($v.arrayValue.values) // []) | map(av(.)))
+            elif $v.kvlistValue != null then
+              (reduce ((($v.kvlistValue.values) // [])[]) as $a ({}; .[$a.key] = av($a.value)))
+            else null end;
+          def kv($arr): reduce (($arr // [])[]) as $a ({}; .[$a.key] = av($a.value));
+
+          (.resourceLogs // [])[] as $rl
+          | kv($rl.resource.attributes) as $res
+          | ($rl.scopeLogs // [])[] as $sl
+          | ($sl.logRecords // [])[] as $lr
+          | ($res + kv($lr.attributes)) as $r
+          | ( ($lr.body.stringValue) as $b
+              | if (($r["event.name"]) // "") != "" then $r["event.name"]
+                elif ($b != null and ($b | startswith("codex."))) then $b
+                else "codex.unknown" end ) as $en
+          | ($en | ltrimstr("codex.")) as $eshort
+          | ($r["model"] // "unknown") as $model
+          | (($r["error.message"] // $r["error"])) as $err
+          | (num($r["http.response.status_code"])) as $status
+
+          # epoch-ms from RFC3339 event.timestamp (ms precision), else timeUnixNano
+          | (if (($r["event.timestamp"]) // "") != ""
+             then (($r["event.timestamp"] | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+             elif (($lr.timeUnixNano) // "") != ""
+             then (($lr.timeUnixNano | tonumber) / 1000000 | floor)
+             else null end) as $rt
+
+          # per-event success + severity
+          | (if $en == "codex.tool_result" then truthy($r["success"])
+             elif $en == "codex.tool_decision" then (($r["decision"] // "approved") | ascii_downcase | startswith("approv"))
+             elif $en == "codex.sandbox_outcome" then ((($r["outcome"] // "") | ascii_downcase) | . == "success" or . == "ok")
+             elif $err != null then false
+             elif ($status != null and $status >= 400) then false
+             else true end) as $ok
+          | (if $ok then 2
+             elif $en == "codex.sandbox_outcome" then 5
+             elif ($err != null or ($status != null and $status >= 400)
+                   or $en == "codex.tool_decision" or $en == "codex.tool_result") then 6
+             else 3 end) as $sev
+
+          | (if $ok then "SUCCESS" else "FAILURE" end) as $outcome
+
+          | ({
+              rt: $rt,
+              suser: $r["user.email"],
+              suid: $r["user.account_id"],
+              act: $eshort,
+              outcome: $outcome,
+              reason: $err,
+              request: $r["endpoint"],
+              app: $r["auth_mode"],
+              cs1Label: "conversationId", cs1: $r["conversation.id"],
+              cs2Label: "model",          cs2: $model,
+              cs3Label: "toolName",       cs3: $r["tool_name"],
+              cs4Label: "decision",       cs4: ($r["decision"] // $r["outcome"]),
+              cs5Label: "sseKind",        cs5: $r["event.kind"],
+              cs6Label: "terminalType",   cs6: $r["terminal.type"],
+              cn1Label: "inputTokens",    cn1: num($r["input_token_count"]),
+              cn2Label: "outputTokens",   cn2: num($r["output_token_count"]),
+              cn3Label: "httpStatus",     cn3: $status
+            }
+            # drop null/empty slots; drop orphan labels whose value is absent
+            | with_entries(select((.value != null) and (.value != "")))
+            | . as $e
+            | reduce (["cs1","cs2","cs3","cs4","cs5","cs6","cn1","cn2","cn3"][]) as $slot
+                ($e; if (.[$slot] == null) then del(.[$slot + "Label"]) else . end)
+            ) as $ext
+
+          | { _cef: {
+                vendor: "OpenAI",
+                product: "Codex",
+                version: ($r["app.version"] // ""),
+                signature_id: $en,
+                name: ($model + " " + $eshort + (if $ok then "" else " (failure)" end)),
+                severity: $sev,
+                extension: $ext
+              } }

--- a/cef/v0/openai/openai-enterprise-audit-logs.yaml
+++ b/cef/v0/openai/openai-enterprise-audit-logs.yaml
@@ -1,0 +1,73 @@
+name: "OpenAI Enterprise Audit Logs to CEF"
+description: "Maps OpenAI Enterprise audit log events to the CEF intermediate contract ({_cef}); the shared CEF serializer renders the final CEF:0 string. Carries actor, source IP, project, API key, and failure details."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "openai-enterprise-audit-logs"
+tags:
+  - "v0"
+  - "cef"
+  - "openai"
+  - "audit-logs"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # -----------------------------------------------------------------
+          # OpenAI Enterprise Audit Logs -> CEF T1 mapping (emits {_cef})
+          # Semantic mapping only; NO escaping (the shared serializer owns it).
+          # times are emitted as epoch-ms; custom slots paired with labels.
+          # -----------------------------------------------------------------
+
+          . as $r
+          | ($r.type // "unknown") as $etype
+          | ($etype | split(".")) as $seg
+          | ($seg[0]) as $head
+          | ($seg[-1]) as $tail
+          | ($r.actor // {}) as $act
+          | ($act.session // {}) as $sess
+          | ($act.api_key // {}) as $ak
+          | ($sess.user // $ak.user // {}) as $u
+          | ($ak.service_account // {}) as $sa
+          | ($sess.ip_address // null) as $ip
+          | ($u.email // null) as $email
+          | ($u.id // $sa.id // $ak.id // null) as $uid
+          | ($r.project // {}) as $proj
+          | ($r[$etype] // {}) as $payload
+          | ($tail == "failed") as $failed
+
+          # severity 0-10: failures highest, then destructive ops, auth, else routine
+          | (if $failed then 6
+             elif ($tail | test("^(deleted|removed|revoked|archived|disabled|deactivated|detached)$")) then 5
+             elif ($head == "login" or $head == "logout") then 3
+             else 4 end) as $sev
+
+          | { "_cef": {
+                "vendor": "OpenAI",
+                "product": "OpenAI Enterprise Audit Logs",
+                "version": "",
+                "signature_id": $etype,
+                "name": $etype,
+                "severity": $sev,
+                "extension": ({
+                  "rt": (if ($r.effective_at | type) == "number" then ($r.effective_at * 1000) else null end),
+                  "suser": ($email // $sa.id // $ak.id // $uid),
+                  "suid": $uid,
+                  "src": $ip,
+                  "act": $etype,
+                  "outcome": (if $failed then "FAILURE" else "SUCCESS" end),
+                  "reason": ($payload.error_message // null),
+                  "externalId": $r.id,
+                  "cs1": ($proj.id // null),
+                  "cs1Label": (if ($proj.id // "") != "" then "projectId" else null end),
+                  "cs2": ($proj.name // null),
+                  "cs2Label": (if ($proj.name // "") != "" then "projectName" else null end),
+                  "cs3": ($ak.id // null),
+                  "cs3Label": (if ($ak.id // "") != "" then "apiKeyId" else null end),
+                  "cs4": ($payload.error_code // null),
+                  "cs4Label": (if ($payload.error_code // "") != "" then "errorCode" else null end)
+                } | with_entries(select((.value != null) and (.value != ""))))
+              } }

--- a/cef/v0/rapid7/rapid7-assets.yaml
+++ b/cef/v0/rapid7/rapid7-assets.yaml
@@ -1,0 +1,69 @@
+name: "Rapid7 InsightVM Assets to CEF"
+description: "Maps Rapid7 InsightVM asset inventory records (GET /api/3/assets) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "rapid7-assets"
+tags:
+  - "v0"
+  - "cef"
+  - "rapid7"
+  - "device"
+  - "inventory"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # Rapid7 InsightVM asset inventory -> CEF intermediate (T1). No
+          # escaping here — the shared CEF Serializer (T2) owns all escaping.
+          # Emit FINAL-FORM values: severity int 0-10; times epoch-MILLISECONDS;
+          # custom slots cs*/cn* paired with their *Label. One jq pass; shallow
+          # null-drop.
+          def to_epoch_ms($ts):
+            if $ts == null or $ts == "" then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) * 1000)
+            end;
+          . as $r |
+          ( ($r.history // []) | map(.date) | map(select(. != null)) | sort ) as $dates |
+          ( if ($dates | length) > 0 then $dates[0]  else null end ) as $first_scan |
+          ( if ($dates | length) > 0 then $dates[-1] else null end ) as $last_scan |
+          ( $r.hostName // ( ($r.hostNames // [])[0] | .name? ) ) as $primary_host |
+          ( $r.ip // ( ($r.addresses // [])[0] | .ip? ) ) as $primary_ip |
+          ( $r.mac // ( ($r.addresses // [])[0] | .mac? ) ) as $primary_mac |
+          { _cef: {
+              vendor: "Rapid7",
+              product: "InsightVM",
+              version: "",
+              signature_id: "rapid7:asset:inventory",
+              name: "Rapid7 Asset Inventory",
+              # Asset inventory snapshots are informational (CEF severity 2).
+              severity: 2,
+              extension: ( {
+                rt:               ( to_epoch_ms($last_scan) // to_epoch_ms($first_scan) // ((now * 1000) | floor) ),
+                start:            to_epoch_ms($first_scan),
+                end:              to_epoch_ms($last_scan),
+                externalId:       ($r.id | tostring),
+                dhost:            $primary_host,
+                dst:              $primary_ip,
+                dmac:             $primary_mac,
+                act:              "inventory",
+                cs1Label:         "operatingSystem",
+                cs1:              ($r.os // $r.osFingerprint.product),
+                cs2Label:         "assetType",
+                cs2:              $r.type,
+                cs3Label:         "osFamily",
+                cs3:              $r.osFingerprint.family,
+                cs4Label:         "osArchitecture",
+                cs4:              $r.osFingerprint.architecture,
+                cn1Label:         "riskScore",
+                cn1:              $r.riskScore,
+                cn2Label:         "criticalVulnerabilities",
+                cn2:              $r.vulnerabilities.critical,
+                cn3Label:         "totalVulnerabilities",
+                cn3:              $r.vulnerabilities.total
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/semgrep/semgrep-deployments.yaml
+++ b/cef/v0/semgrep/semgrep-deployments.yaml
@@ -1,0 +1,48 @@
+name: "Semgrep Deployments to CEF"
+description: "Maps Semgrep Deployment (org/tenant) inventory records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "semgrep-deployments"
+tags:
+  - "v0"
+  - "cef"
+  - "semgrep"
+  - "deployment"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Semgrep Deployments -> CEF intermediate (T1).
+          # Input: ONE Semgrep Deployment record (Semgrep API GET /deployments).
+          # A deployment is a Semgrep org/tenant — inventory metadata — so this
+          # is a low-severity informational inventory signature.
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values (severity 0-10; times epoch-ms;
+          # custom slots paired with their *Label). One jq pass; shallow
+          # null-drop on the extension object (no recursive walk).
+          # ---------------------------------------------------------------
+          . as $r
+          | { _cef: {
+              vendor: "Semgrep",
+              product: "Semgrep AppSec Platform",
+              version: "",
+              signature_id: "semgrep.deployment.inventory",
+              name: ("Semgrep deployment inventory: " + ($r.name // $r.slug)),
+              severity: 2,
+              extension: ( {
+                rt:          (now * 1000 | floor),      # no source time; stamp at collection (epoch-ms)
+                cn1Label:    "deploymentId",
+                cn1:         $r.id,                      # Semgrep deployment id (numeric)
+                cs1Label:    "deploymentSlug",
+                cs1:         $r.slug,
+                cs2Label:    "deploymentName",
+                cs2:         $r.name,
+                cs3Label:    "findingsUrl",
+                cs3:         ($r.findings.url // null)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/semgrep/semgrep-project-details.yaml
+++ b/cef/v0/semgrep/semgrep-project-details.yaml
@@ -1,0 +1,65 @@
+name: "Semgrep Project Metadata to CEF"
+description: "Maps a Semgrep Project Metadata (repository/project inventory) record into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+# author is ALWAYS "Monad" — never a person. You are a contributor.
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "semgrep-project-details"
+tags:
+  - "v0"
+  - "cef"
+  - "semgrep"
+  - "project"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Semgrep Project Metadata -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values (severity 0-10, times as
+          # epoch-MILLISECONDS, custom slots paired with their *Label).
+          # One jq pass, per-record only.
+          # ---------------------------------------------------------------
+
+          # Semgrep timestamps ("2020-11-18 23:28:12.391807+00:00") aren't
+          # strict ISO-8601; normalize before fromdateiso8601, then *1000.
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number"
+              then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else ( ( $ts
+                     | gsub("\\.[0-9]+"; "")
+                     | sub(" "; "T")
+                     | sub("[+-][0-9][0-9]:?[0-9][0-9]$"; "Z")
+                     | (if test("Z$") then . else . + "Z" end)
+                     | fromdateiso8601 ) * 1000 )
+            end;
+
+          def present($v): $v != null and $v != "";
+
+          . as $r
+          | { "_cef": {
+              "vendor":       "Semgrep",
+              "product":      "Semgrep Projects",
+              "version":      "",
+              "signature_id": "semgrep.project.metadata",
+              "name":         "Semgrep project metadata",
+              "severity":     2,                        # informational inventory
+              "extension": (
+                ( { "act": "project-metadata-collected" }
+                  + (if present($r.latest_scan_at) then { "rt": to_epoch_ms($r.latest_scan_at) } else {} end)
+                  + (if present($r.created_at)     then { "start": to_epoch_ms($r.created_at) } else {} end)
+                  + (if present($r.url)            then { "request": $r.url } else {} end)
+                  + (if $r.id != null              then { "cn1Label": "projectId", "cn1": $r.id } else {} end)
+                  + (if present($r.name)           then { "cs1Label": "projectName", "cs1": $r.name } else {} end)
+                  + (if present($r.primary_branch) then { "cs2Label": "primaryBranch", "cs2": $r.primary_branch } else {} end)
+                  + (if present($r.default_branch) then { "cs3Label": "defaultBranch", "cs3": $r.default_branch } else {} end)
+                  + (if ($r.tags | type) == "array" and ($r.tags | length) > 0
+                       then { "cs4Label": "tags", "cs4": ($r.tags | join(",")) } else {} end)
+                )
+              )
+          } }

--- a/cef/v0/semgrep/semgrep-projects.yaml
+++ b/cef/v0/semgrep/semgrep-projects.yaml
@@ -1,0 +1,58 @@
+name: "Semgrep Projects to CEF"
+description: "Maps Semgrep project (scanned-repository) inventory records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "semgrep-projects"
+tags:
+  - "v0"
+  - "cef"
+  - "semgrep"
+  - "projects"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Semgrep project inventory -> CEF intermediate (T1). No escaping —
+          # the shared CEF Serializer (T2) owns all escaping. Emit final-form
+          # values: severity 0-10, times epoch-MILLISECONDS, custom slots
+          # paired with their *Label. One jq pass; shallow null-drop.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | sub(" "; "T") | sub("\\.[0-9]+"; "")
+                   | sub("([+-][0-9][0-9]:[0-9][0-9]|Z)$"; "") + "Z"
+                   | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.tags // []) as $tags
+          | { _cef: {
+              vendor: "Semgrep",
+              product: "Semgrep Cloud Platform",
+              version: "",
+              signature_id: "semgrep.project.inventory",
+              name: ("Semgrep project inventory: " + ($r.name // "unknown")),
+              severity: 2,
+              extension: ( {
+                rt:      to_epoch_ms($r.created_at),
+                dvchost: $r.name,
+                request: $r.url,
+                act:     "collect",
+                cn1Label: "projectId",
+                cn1:     $r.id,
+                cs1Label: "primaryBranch",
+                cs1:     $r.primary_branch,
+                cs2Label: "defaultBranch",
+                cs2:     $r.default_branch,
+                cs3Label: "tags",
+                cs3:     (if ($tags | length) > 0 then ($tags | join(",")) else null end),
+                deviceCustomDate1Label: "latestScanAt",
+                deviceCustomDate1: to_epoch_ms($r.latest_scan_at)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/snyk/snyk-organizations.yaml
+++ b/cef/v0/snyk/snyk-organizations.yaml
@@ -1,0 +1,53 @@
+name: "Snyk Organizations to CEF"
+description: "Maps Snyk Organization inventory records (Snyk REST GET /orgs) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+# author is ALWAYS "Monad" — never a person. You are a contributor.
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "snyk-organizations"
+tags:
+  - "v0"
+  - "cef"
+  - "snyk"
+  - "organizations"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Snyk Organizations -> CEF intermediate (T1).
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values: severity int 0-10, times
+          # epoch-MILLISECONDS, custom slots cs* paired with their *Label.
+          # One jq pass; shallow null-drop on extension (no recursive walk).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.attributes // {}) as $a
+          | { _cef: {
+              vendor: "Snyk",
+              product: "Snyk",
+              version: "",
+              signature_id: "org.inventory",
+              name: ("Snyk Organization Inventory: " + ($a.name // $r.id)),
+              severity: 1,
+              extension: ( {
+                rt:         to_epoch_ms($a.created_at),
+                externalId: $r.id,
+                deviceCustomDate1Label: "createdAt",
+                deviceCustomDate1: to_epoch_ms($a.created_at),
+                cs1Label: "orgName",  cs1: $a.name,
+                cs2Label: "orgSlug",  cs2: $a.slug,
+                cs3Label: "groupId",  cs3: $a.group_id,
+                cs4Label: "isPersonal", cs4: ($a.is_personal | tostring),
+                cs5Label: "accessRequestsEnabled", cs5: ($a.access_requests_enabled | tostring)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/snyk/snyk-projects.yaml
+++ b/cef/v0/snyk/snyk-projects.yaml
@@ -1,0 +1,54 @@
+name: "Snyk Project Metadata to CEF"
+description: "Maps Snyk Project Metadata into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "snyk-projects"
+tags:
+  - "v0"
+  - "cef"
+  - "snyk"
+  - "inventory"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Snyk /projects -> CEF intermediate (T1). NO escaping here.
+          # severity: integer 0-10 ; rt: epoch-MILLISECONDS ;
+          # custom slots cs*/cn* always paired with their *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.attributes // {}) as $a
+          | ( ($a.business_criticality // []) | if type == "array" then .[0] else . end ) as $crit
+          | { _cef: {
+              vendor: "Snyk",
+              product: "Snyk",
+              version: "",
+              signature_id: "project",
+              name: ($a.name // "Snyk Project"),
+              severity: (
+                { "low": 3, "medium": 5, "high": 8, "critical": 10 }[$crit // ""] // 0
+              ),
+              extension: ( {
+                rt:         to_epoch_ms($a.created),
+                externalId: $r.id,
+                fname:      $a.target_file,
+                msg:        $a.name,
+                cs1Label: "projectType",         cs1: $a.type,
+                cs2Label: "origin",              cs2: $a.origin,
+                cs3Label: "status",              cs3: $a.status,
+                cs4Label: "businessCriticality", cs4: $crit,
+                cs5Label: "environment",         cs5: (($a.environment // []) | if type == "array" then join(",") else . end),
+                cs6Label: "lifecycle",           cs6: (($a.lifecycle // []) | if type == "array" then join(",") else . end)
+              } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/snyk/snyk-targets.yaml
+++ b/cef/v0/snyk/snyk-targets.yaml
@@ -1,0 +1,66 @@
+name: "Snyk Scan Targets to CEF"
+description: "Maps Snyk Scan Target (source/repo inventory) records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "snyk-targets"
+tags:
+  - "v0"
+  - "cef"
+  - "snyk"
+  - "targets"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Snyk /orgs/{org_id}/targets -> CEF intermediate (T1). NO escaping.
+          # A "target" is a scanned source (repo / registry / etc.).
+          # severity: integer 0-10 (informational inventory -> 2) ;
+          # rt: epoch-MILLISECONDS ; custom slots cs* paired with their *Label.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.attributes // {}) as $a
+          | ($r.relationships // {}) as $rel
+          | ($rel.integration.data.attributes.integration_type) as $itype
+          | ($rel.organization.data.id) as $org_id
+          | ($a.url // "") as $url
+          | ( ($url | ltrimstr("https://") | ltrimstr("http://") | split("/") | .[0]) // "" ) as $host
+          | ( ($itype // ($host | ascii_downcase
+                | if contains("github") then "github"
+                  elif contains("gitlab") then "gitlab"
+                  elif contains("bitbucket") then "bitbucket"
+                  elif (contains("azure") or contains("visualstudio")) then "azure-repos"
+                  else . end)) ) as $provider0
+          | ( if ($provider0 // "") == "" then null else $provider0 end ) as $provider
+          | { _cef: {
+              vendor: "Snyk",
+              product: "Snyk",
+              version: "",
+              signature_id: "scan_target",
+              name: ("Snyk scan target: " + ($a.display_name // $r.id)),
+              severity: 2,
+              extension: ( (
+                {
+                  rt:      to_epoch_ms($a.created_at),
+                  act:     "scan-target-inventory",
+                  request: ( if $url == "" then null else $url end ),
+                  dhost:   ( if $host == "" then null else $host end )
+                }
+                + ( if $provider                 then { cs1Label: "sourceType",     cs1: $provider } else {} end )
+                + ( if $a.display_name            then { cs2Label: "displayName",    cs2: $a.display_name } else {} end )
+                + ( if $r.id                      then { cs3Label: "targetId",       cs3: $r.id } else {} end )
+                + ( if $org_id                    then { cs4Label: "organizationId", cs4: $org_id } else {} end )
+                + ( if $rel.integration.data.id   then { cs5Label: "integrationId",  cs5: $rel.integration.data.id } else {} end )
+                + ( if $a.is_private != null      then { cs6Label: "isPrivate",      cs6: ($a.is_private | tostring) } else {} end )
+              ) | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/socket/socket-full-scans.yaml
+++ b/cef/v0/socket/socket-full-scans.yaml
@@ -1,0 +1,87 @@
+name: "Socket Full Scan Findings to CEF"
+description: "Maps Socket.dev full-scan SBOM artifact records into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "socket-full-scans"
+tags:
+  - "v0"
+  - "cef"
+  - "socket"
+  - "full-scans"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Socket.dev full-scan SBOM artifact -> CEF intermediate (T1).
+          # Input: ONE Socket artifact per invocation (one scanned package
+          #   with an alerts[] array). CEF carries one event, so the WORST
+          #   alert drives the signature/name/severity; the full alert set is
+          #   preserved in custom-string slots.
+          # Do NOT escape anything here — the shared CEF Serializer (T2) owns
+          # all escaping. Emit FINAL-FORM values (severity 0-10, times epoch-ms,
+          # every cs*/cn*/cfp* slot paired with its *Label).
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          # Socket severity label -> ordering rank and CEF 0-10 severity.
+          def sev_rank:
+            (. // "" | ascii_downcase) as $s |
+            if   $s == "critical" then 4
+            elif $s == "high"     then 3
+            elif $s == "middle" or $s == "medium" then 2
+            elif $s == "low"      then 1
+            else 0 end;
+          def rank_to_cef($n):
+            {"4":10,"3":8,"2":5,"1":3,"0":1}[$n|tostring] // 0;
+
+          . as $r
+          | ($r.alerts // []) as $alerts
+
+          | ( ($r.inputPurl)
+              // ( "pkg:" + ($r.type // "generic")
+                   + (if ($r.namespace // "") != "" then "/" + $r.namespace else "" end)
+                   + "/" + ($r.name // "unknown")
+                   + (if ($r.version // "") != "" then "@" + $r.version else "" end) )
+            ) as $purl
+
+          # The worst alert drives the CEF header.
+          | ( ($alerts | sort_by(.severity | sev_rank) | last) // {} ) as $worst
+          | ( [ $alerts[] | .type | select(. != null) ] | unique ) as $alert_types
+          | ( [ $alerts[] | .props.cveId | select(. != null) ] | unique ) as $cves
+
+          | { _cef: {
+                vendor: "Socket",
+                product: "Socket Full Scans",
+                version: "",
+                # signature = the worst alert's type; stable + low-cardinality.
+                signature_id: ($worst.type // "supplyChainScan"),
+                name: ( "Socket "
+                        + ($worst.type // "supply-chain scan")
+                        + " on " + ($r.name // "unknown")
+                        + "@" + ($r.version // "?") ),
+                severity: rank_to_cef($worst.severity | sev_rank),
+                extension: ( {
+                  rt:       to_epoch_ms($r.publishedAt),
+                  outcome:  ($worst.action),                       # error / warn / ignore
+                  msg:      ($worst.props.description // $worst.props.note),
+                  fname:    ($worst.file),
+                  cat:      ($worst.category),
+                  cs1Label: "packagePurl",   cs1: $purl,
+                  cs2Label: "ecosystem",     cs2: ($r.type),
+                  cs3Label: "cveIds",        cs3: (if ($cves | length) > 0 then ($cves | join(",")) else null end),
+                  cs4Label: "alertTypes",    cs4: (if ($alert_types | length) > 0 then ($alert_types | join(",")) else null end),
+                  cs5Label: "packageLicense", cs5: ($r.license),
+                  cn1Label: "alertCount",    cn1: ($alerts | length),
+                  cn2Label: "directDependency", cn2: (if ($r.direct == true) then 1 elif ($r.direct == false) then 0 else null end),
+                  cfp1Label: "cvssScore",    cfp1: ([ $alerts[] | .props.cvssScore | select(. != null) ] | max)
+                } | with_entries(select(.value != null and .value != "")) )
+          } }

--- a/cef/v0/veracode/veracode-applications.yaml
+++ b/cef/v0/veracode/veracode-applications.yaml
@@ -1,0 +1,61 @@
+name: "Veracode Applications to CEF"
+description: "Maps Veracode Applications API records (application inventory and policy-compliance posture) into the normalized {_cef:{...}} CEF intermediate. Chain the shared CEF Serializer (utility/cef/cef-serializer.yaml) after this to render the CEF:0 string."
+author: "Monad"
+contributors:
+  - "https://github.com/behobu"
+inputs:
+  - "veracode-applications"
+tags:
+  - "v0"
+  - "cef"
+  - "veracode"
+  - "applications"
+config:
+  operations:
+    - operation: "jq"
+      arguments:
+        key: ""
+        query: |
+          # ---------------------------------------------------------------
+          # Veracode Applications -> CEF intermediate (T1). No escaping here.
+          # Emit FINAL-FORM values: severity 0-10, times epoch-MILLISECONDS,
+          # custom slots paired with their *Label. One jq pass; shallow
+          # null-drop on the extension object only.
+          # ---------------------------------------------------------------
+          def to_epoch_ms($ts):
+            if $ts == null then null
+            elif ($ts | type) == "number" then (if $ts > 1e12 then $ts else ($ts * 1000) end | floor)
+            else (($ts | gsub("\\.[0-9]+Z?$"; "Z") | fromdateiso8601) * 1000)
+            end;
+
+          . as $r
+          | ($r.profile // {}) as $p
+          | (($p.policies // []) | .[0]) as $pol
+          | ($pol.policy_compliance_status // null) as $pcs
+          | (($p.business_owners // []) | .[0]) as $owner
+          | { _cef: {
+              vendor: "Veracode",
+              product: "Veracode Application Security",
+              version: "",
+              signature_id: "veracode.application.posture",
+              name: ( "Application security posture: " + ($p.name // "unknown") ),
+              # business_criticality -> CEF severity bucket (0-10)
+              severity: ( { "VERY_HIGH": 10, "HIGH": 8, "MEDIUM": 5, "LOW": 3, "VERY_LOW": 1 }[$p.business_criticality // ""] // 0 ),
+              extension: ( {
+                rt:            to_epoch_ms($r.modified),
+                end:          to_epoch_ms($r.last_completed_scan_date),
+                deviceExternalId: $r.guid,
+                externalId:    ( $r.id | tostring ),
+                act:           "policy-compliance-check",
+                outcome:       ( { "PASSED": "SUCCESS", "DID_NOT_PASS": "FAILURE" }[$pcs // ""] // $pcs ),
+                duser:         $owner.email,
+                dvchost:       "analysiscenter.veracode.com",
+                # Custom slots (paired with labels) for fields with no dictionary home:
+                cs1Label: "applicationName",       cs1: $p.name,
+                cs2Label: "businessCriticality",   cs2: $p.business_criticality,
+                cs3Label: "policyComplianceStatus", cs3: $pcs,
+                cs4Label: "policyName",            cs4: $pol.name,
+                cs5Label: "businessUnit",          cs5: ( ($p.business_unit // {}).name ),
+                cs6Label: "tags",                  cs6: $p.tags
+              } | with_entries(select(.value != null and .value != "")) )
+          } }


### PR DESCRIPTION
Adds ~61 more per-source vendor→**CEF v0** `{_cef}` T1 mappings under cef/v0/<vendor>/ (authored from vendor docs via the cef-transform-builder skill; each chain validated through the shared serializer), including cursor-audit-logs.

The initial batch (30 inputs) already merged; this PR carries the remaining validated transforms pushed to the branch since. Each passed its format's offline validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)